### PR TITLE
fix: Dockerfile 移動 + ドキュメント陳腐化修正

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,10 +24,10 @@ COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --no-dev --no-install-project
 
 # エントリーポイントだけコピー（これは固定なのでイメージに含める）
-COPY scripts/vertex_entrypoint.py ./scripts/vertex_entrypoint.py
+COPY scripts/remote_entrypoint.py ./scripts/remote_entrypoint.py
 
 # src/ は GCS から取得するため PYTHONPATH で解決する
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 
-ENTRYPOINT ["uv", "run", "python", "/app/scripts/vertex_entrypoint.py"]
+ENTRYPOINT ["uv", "run", "python", "/app/scripts/remote_entrypoint.py"]

--- a/docs/manual/1001_vertex-ai-training.md
+++ b/docs/manual/1001_vertex-ai-training.md
@@ -102,7 +102,7 @@ uv run python -m src usecase=vertex_train recipe=lgbm
 
 | ファイル | 役割 |
 |---------|------|
-| `conf/usecase/vertex_train.yaml` | vertex_train usecase の設定 |
+| `conf/usecase/remote_train.yaml` | remote_train usecase の設定（`vertex_train` はエイリアス） |
 | `conf/gcp/vertex.yaml` | GCP プロジェクト・リージョン・マシンタイプ等（`.env` から読む） |
 | `conf/competition/titanic/training/lgbm.yaml` | LightGBM ハイパーパラメータ（`titanic` は `conf/config.yaml` のデフォルト competition） |
 
@@ -240,7 +240,7 @@ uv run python -m src usecase=pipeline recipe=vertex_to_kaggle
 | Step | 内容 | 使用 config |
 |------|------|------------|
 | ① preprocess | 前処理 | `conf/competition/{name}/preprocess/base.yaml` |
-| ② vertex_train | Vertex AI で学習 | `conf/competition/{name}/training/lgbm.yaml` |
+| ② remote_train | Vertex AI で学習 | `conf/competition/{name}/training/lgbm.yaml` |
 | ③ inference | 推論（submission.csv 生成） | `conf/competition/{name}/inference/titanic_ensemble.yaml` |
 | ④ update_source_dataset | コードを `mlops-pipeline-src` に push | `conf/usecase/update_source_dataset.yaml` |
 | ⑤ update_source_dataset | モデルを `titanic-vertex-models` に push | ⑤ は pipeline yaml 内で直接定義 |
@@ -260,7 +260,7 @@ Kaggle プリビルトイメージで不足するパッケージがある場合�
 
 | ファイル | 役割 |
 |---------|------|
-| `Dockerfile` | カスタムイメージ定義 |
+| `docker/Dockerfile` | カスタムイメージ定義 |
 | `scripts/docker_push.sh` | ビルド + push スクリプト |
 
 push 後、`conf/gcp/vertex.yaml` の `container_uri` を変更:

--- a/docs/tasks/2026/Q1/0325_dockerfile-and-docs-stale-references/README.md
+++ b/docs/tasks/2026/Q1/0325_dockerfile-and-docs-stale-references/README.md
@@ -1,0 +1,19 @@
+# Dockerfile 移動 + ドキュメント陳腐化修正
+
+## 背景
+
+PR #34 (Clean Architecture Naming 準拠) で `vertex_entrypoint.py` → `remote_entrypoint.py` にリネームされたが、Dockerfile とマニュアルが未更新。Dockerfile のビルドが壊れている。
+
+## 修正内容
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `Dockerfile` → `docker/Dockerfile` | 移動 + `vertex_entrypoint.py` → `remote_entrypoint.py` に修正 |
+| `scripts/docker_push.sh` | `-f docker/Dockerfile` 追加 |
+| `docs/manual/1001_vertex-ai-training.md` | usecase 名修正 (`vertex_train` → `remote_train`) + Dockerfile パス修正 |
+
+## 検証方法
+
+1. `grep -r "vertex_entrypoint" .` で残存参照がないこと
+2. マニュアル内のコマンドが整合すること
+3. lefthook（ruff, ty, pytest）が通ること

--- a/docs/tasks/2026/Q1/0325_dockerfile-and-docs-stale-references/timeline.md
+++ b/docs/tasks/2026/Q1/0325_dockerfile-and-docs-stale-references/timeline.md
@@ -1,0 +1,15 @@
+# Timeline: Dockerfile 移動 + ドキュメント陳腐化修正
+
+## 2026-03-25
+
+### 作業開始
+
+- ブランチ `fix/dockerfile-and-docs-stale-references` を `origin/main` から作成
+- 対象ファイルの確認完了
+
+### 実装
+
+- テスト不要（Dockerfile 移動 + ドキュメント修正のみ、Python コード変更なし）
+- Dockerfile を `docker/Dockerfile` に移動し、entrypoint パスを修正
+- `scripts/docker_push.sh` のビルドコマンドを更新
+- `docs/manual/1001_vertex-ai-training.md` の陳腐化した参照を修正

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -31,7 +31,7 @@ IMAGE_URI="${REGION}-docker.pkg.dev/${GCP_PROJECT}/mlops/training:latest"
 
 echo "=== Docker build ==="
 echo "Image: ${IMAGE_URI}"
-docker build -t "$IMAGE_URI" "$PROJECT_ROOT"
+docker build -f "$PROJECT_ROOT/docker/Dockerfile" -t "$IMAGE_URI" "$PROJECT_ROOT"
 
 echo ""
 echo "=== Docker push ==="


### PR DESCRIPTION
## Summary

- `Dockerfile` → `docker/Dockerfile` に移動し、`vertex_entrypoint.py` → `remote_entrypoint.py` への参照を修正（PR #34 のリネーム漏れ）
- `scripts/docker_push.sh` に `-f docker/Dockerfile` を追加
- `docs/manual/1001_vertex-ai-training.md` の `vertex_train` → `remote_train` 修正 + Dockerfile パス更新

## Test plan

- [x] `grep -r "vertex_entrypoint"` で実コード・設定に残存参照がないこと確認済み（タスクドキュメントのみ）
- [x] lefthook（ruff, ty, mille-check）全パス
- [ ] CI が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)