### PR TITLE
fix: push_notebook usecase yaml を routing-only 化

### DIFF
--- a/conf/competition/histopathologic/notebook/histopathologic_inference.yaml
+++ b/conf/competition/histopathologic/notebook/histopathologic_inference.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+# Histopathologic 推論用 Notebook の Kaggle push 設定
+#
+# 実行例:
+#   uv run python -m src usecase=push_notebook competition=histopathologic recipe=histopathologic_inference
+
+notebook:
+  competition: histopathologic-cancer-detection
+  kernel_slug: histopathologic-inference
+  src_dataset: mlops-pipeline-src
+  recipe: inference_only
+  enable_gpu: false
+  enable_internet: false
+  extra_datasets: []

--- a/conf/competition/histopathologic/pipeline/full.yaml
+++ b/conf/competition/histopathologic/pipeline/full.yaml
@@ -38,4 +38,11 @@ steps:
 
   # ⑦ 推論用 Notebook を Kaggle に push
   - usecase: push_notebook
-    notebook: histopathologic_inference
+    notebook:
+      competition: histopathologic-cancer-detection
+      kernel_slug: histopathologic-inference
+      src_dataset: mlops-pipeline-src
+      recipe: inference_only
+      enable_gpu: false
+      enable_internet: false
+      extra_datasets: []

--- a/conf/competition/titanic/notebook/all_after_download.yaml
+++ b/conf/competition/titanic/notebook/all_after_download.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+# Titanic パイプライン全体 Notebook の Kaggle push 設定
+#
+# 実行例:
+#   uv run python -m src usecase=push_notebook recipe=all_after_download
+
+notebook:
+  competition: titanic
+  kernel_slug: titanic-pipeline
+  src_dataset: mlops-pipeline-src
+  recipe: all_after_download
+  enable_gpu: false
+  enable_internet: false
+  extra_datasets: []

--- a/conf/competition/titanic/notebook/inference_only.yaml
+++ b/conf/competition/titanic/notebook/inference_only.yaml
@@ -1,0 +1,16 @@
+# @package _global_
+# Titanic Vertex AI 推論専用 Notebook の Kaggle push 設定
+#
+# 実行例:
+#   uv run python -m src usecase=push_vertex_notebook recipe=inference_only
+
+notebook:
+  competition: titanic
+  kernel_slug: titanic-vertex-inference
+  recipe: inference_only
+  src_dataset: mlops-pipeline-src
+  extra_datasets:
+    - slug: titanic-vertex-models
+      mount_path: /kaggle/working/models/titanic
+  enable_gpu: false
+  enable_internet: false

--- a/conf/usecase/push_notebook.yaml
+++ b/conf/usecase/push_notebook.yaml
@@ -1,13 +1,11 @@
 # @package _global_
+# push_notebook usecase のルーティング設定。
+#
+# competition 固有パラメータ（competition, kernel_slug, src_dataset 等）は
+# conf/competition/{slug}/notebook/{recipe}.yaml に記述する。
+#
+# 実行例:
+#   uv run python -m src usecase=push_notebook recipe=all_after_download
 usecase: push_notebook
-
-notebook:
-  competition: titanic            # Kaggle competition slug（input として追加）
-  kernel_slug: titanic-pipeline   # Kaggle Kernel の URL slug
-  src_dataset: mlops-pipeline-src # src/ を格納する Kaggle Dataset slug
-  recipe: all_after_download       # Notebook 内で実行するパイプラインレシピ
-  enable_gpu: false
-  enable_internet: false
-  extra_datasets: []              # 追加 Dataset sources（例: [mlops-vertex-models]）
 
 output_dir: notebooks

--- a/conf/usecase/push_vertex_notebook.yaml
+++ b/conf/usecase/push_vertex_notebook.yaml
@@ -1,18 +1,11 @@
 # @package _global_
-# Vertex AI 推論専用 Notebook を Kaggle に push する設定
+# Vertex AI 推論専用 Notebook を Kaggle に push する設定のルーティング。
 #
-# 実行: uv run python -m src usecase=push_vertex_notebook
+# competition 固有パラメータ（competition, kernel_slug, src_dataset 等）は
+# conf/competition/{slug}/notebook/{recipe}.yaml に記述する。
+#
+# 実行例:
+#   uv run python -m src usecase=push_vertex_notebook recipe=inference_only
 usecase: push_notebook
-
-notebook:
-  competition: titanic
-  kernel_slug: titanic-vertex-inference
-  recipe: inference_only
-  src_dataset: mlops-pipeline-src
-  extra_datasets:
-    - slug: titanic-vertex-models
-      mount_path: /kaggle/working/models/titanic
-  enable_gpu: false
-  enable_internet: false
 
 output_dir: notebooks

--- a/docs/manual/0700_push-notebook.md
+++ b/docs/manual/0700_push-notebook.md
@@ -50,8 +50,12 @@ uv run python -m src usecase=update_source_dataset source_dataset.version_messag
 
 ### ステップ 2: Notebook を生成して Kaggle にプッシュ
 
+`conf/usecase/push_notebook.yaml` は routing-only（`usecase`, `output_dir` のみ）。
+competition 固有パラメータ（`competition`, `kernel_slug`, `src_dataset` 等）は
+`conf/competition/{slug}/notebook/{recipe}.yaml` に記述し、`recipe=` で選択する。
+
 ```bash
-uv run python -m src usecase=push_notebook notebook.competition=titanic
+uv run python -m src usecase=push_notebook competition=titanic recipe=all_after_download
 ```
 
 ### ステップ 3: Kaggle Notebook で実行
@@ -134,7 +138,7 @@ steps:
 
 ```bash
 uv run python -m src usecase=update_source_dataset source_dataset.version_message="add inference_only recipe"
-uv run python -m src usecase=push_notebook notebook.competition=titanic
+uv run python -m src usecase=push_vertex_notebook competition=titanic recipe=inference_only
 ```
 
 ### 3. Notebook のセル 2 を変更
@@ -200,7 +204,7 @@ uv run kaggle datasets version -p .packages/ -m "update packages" -r zip
 
 ### 3. Notebook の dataset_sources に追加
 
-`conf/usecase/push_notebook.yaml` を編集して `packages_dataset` を追加:
+`conf/competition/titanic/notebook/all_after_download.yaml` を編集して `packages_dataset` を追加:
 
 ```yaml
 notebook:
@@ -213,7 +217,7 @@ notebook:
 ```
 
 > **現状の制限**: `packages_dataset` と `enable_internet: false` は
-> `conf/usecase/push_notebook.yaml` と `kernel-metadata.json` の手動編集が必要。
+> `conf/competition/{slug}/notebook/{recipe}.yaml` と `kernel-metadata.json` の手動編集が必要。
 > 将来的には `push_notebook` usecase が自動反映する予定。
 
 手動で `notebooks/titanic/kernel-metadata.json` を編集する場合:
@@ -276,28 +280,43 @@ subprocess.check_call([
 
 ## 設定変更リファレンス
 
-### コンペを変える
+competition 固有パラメータは `conf/competition/{slug}/notebook/{recipe}.yaml` に書く
+（`conf/usecase/push_notebook.yaml` は routing-only なので編集しない）。
+
+### 新しいコンペ用の notebook recipe を追加する
 
 ```bash
-uv run python -m src usecase=push_notebook notebook.competition=otto
+mkdir -p conf/competition/otto/notebook
 ```
 
-### kernel_slug（URL名）を変える
+```yaml
+# conf/competition/otto/notebook/all_after_download.yaml
+# @package _global_
+notebook:
+  competition: otto
+  kernel_slug: otto-pipeline
+  src_dataset: mlops-pipeline-src
+  recipe: all_after_download
+  enable_gpu: false
+  enable_internet: false
+  extra_datasets: []
+```
 
 ```bash
-uv run python -m src usecase=push_notebook notebook.competition=titanic notebook.kernel_slug=titanic-v2
+uv run python -m src usecase=push_notebook competition=otto recipe=all_after_download
 ```
 
-### GPU を有効にする
+### kernel_slug（URL名）や GPU 設定を変える
 
-```bash
-uv run python -m src usecase=push_notebook notebook.competition=titanic notebook.enable_gpu=true
-```
+recipe yaml のフィールドが常に優先される（CLI からの一時上書きは未対応）ため、
+`conf/competition/{slug}/notebook/{recipe}.yaml` を直接編集する。
+一時的に試したい場合は別の recipe ファイル（例: `all_after_download_v2.yaml`）を作成し
+`recipe=all_after_download_v2` で切り替える。
 
 ### src_dataset のスラッグを変える
 
 ```yaml
-# conf/usecase/push_notebook.yaml
+# conf/competition/titanic/notebook/all_after_download.yaml
 notebook:
   src_dataset: my-custom-src-dataset
 ```

--- a/docs/tasks/2026/Q2/0625_notebook-config-routing/README.md
+++ b/docs/tasks/2026/Q2/0625_notebook-config-routing/README.md
@@ -1,0 +1,48 @@
+# push_notebook / push_vertex_notebook の routing-only 化
+
+## 背景
+
+`conf/usecase/push_notebook.yaml` と `conf/usecase/push_vertex_notebook.yaml` に
+`competition: titanic`, `kernel_slug: titanic-pipeline` 等の競技固有値がハードコードされており、
+別コンペで `uv run python -m src usecase=push_notebook` を直接実行すると常に titanic 向けの値が使われてしまう
+（caution.md の「usecase の config に インフラ固有の設定を混在させない」原則に違反）。
+
+調査の結果、姉妹リポジトリ `../bird-clef-2026` で同種の修正（commit `924e863`）が行われていたが、
+usecase yaml を routing-only にしただけで、`recipe=` から competition 固有 yaml を読み込むマージ処理が
+追加されておらず、ドキュメントコメントに書かれた `notebook=all_after_download` という起動方法は実際には機能しない
+（`run_push_notebook` に merge 呼び出しがなく、直接 CLI 実行時は `cfg.notebook` が `null` のまま）。
+B 側では pipeline usecase 経由でのみ動作しており、単体実行は実質未対応のまま放置されていた。
+
+また、調査中に `conf/competition/histopathologic/pipeline/full.yaml` の step 7
+（`notebook: histopathologic_inference`）が文字列のまま渡されており、
+`PushNotebookUseCase` が `cfg.notebook.competition` にアクセスする箇所で `AttributeError` になる
+既存バグを発見した（テストなし・未実行のため検出されていなかった）。
+
+## やること
+
+1. `conf/usecase/push_notebook.yaml` / `push_vertex_notebook.yaml` を routing-only にする
+   （`usecase: push_notebook` と `output_dir` のみ）。
+2. `src/usecase/notebook/notebook_loader.py` を新設し、既存の
+   `pipeline_loader.py` / `trainer_loader.py` と同じパターンで
+   `load_notebook_recipe_cfg(cfg, conf_dir)` を実装する
+   （`cfg.recipe` から `conf/competition/{competition.name}/notebook/{recipe}.yaml` をロードしてマージ）。
+3. `src/presentation/runners.py` の `run_push_notebook` で `load_notebook_recipe_cfg` を呼び、
+   単体実行（pipeline 経由でない直接 CLI 実行）でも competition 固有値が解決されるようにする。
+   pipeline 経由（step で `notebook:` を直接 dict 指定）の場合は `cfg.notebook` が既に解決済みなので
+   `recipe` が無ければ何もしない（既存の `load_pipeline_recipe_cfg` と同じ早期 return パターン）。
+4. `conf/competition/titanic/notebook/all_after_download.yaml` /
+   `conf/competition/titanic/notebook/inference_only.yaml` を新設し、
+   旧 `push_notebook.yaml` / `push_vertex_notebook.yaml` にあった値を移植する。
+5. `conf/competition/histopathologic/pipeline/full.yaml` の step 7 を
+   文字列指定からインライン dict 指定に修正し、既存バグを解消する。
+6. テスト:
+   - `load_notebook_recipe_cfg` の単体テスト（recipe 指定あり/なし/存在しない場合）
+   - `conf/competition/histopathologic/pipeline/full.yaml` を `build_step_configs` に通し、
+     notebook step の cfg が dict 形状であることを検証する回帰テスト
+7. `docs/manual/` に直接実行コマンド例を追記する。
+
+## 対象外（スコープ外）
+
+- `trainer_loader.py` / `inference_loader.py` / `pipeline_loader.py` の重複コードの統合
+  （再利用性向上の余地はあるが、今回は push_notebook 単体の不具合修正にとどめる。別タスクで検討）
+- BirdCLEF 固有の SeedFixer Protocol 化・input_dim ルールは別タスク（#2, #3）で対応する

--- a/docs/tasks/2026/Q2/0625_notebook-config-routing/TEST_LOG_20260625_164355.md
+++ b/docs/tasks/2026/Q2/0625_notebook-config-routing/TEST_LOG_20260625_164355.md
@@ -1,0 +1,37 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.5, pytest-9.0.2, pluggy-1.6.0 -- /home/hope/workspace/mlops/.venv/bin/python3
+cachedir: .pytest_cache
+rootdir: /home/hope/workspace/mlops
+configfile: pyproject.toml
+plugins: anyio-4.12.1, cov-7.0.0, hydra-core-1.3.2
+collecting ... collected 0 items / 1 error
+
+==================================== ERRORS ====================================
+_______ ERROR collecting tests/usecase/notebook/test_notebook_loader.py ________
+ImportError while importing test module '/home/hope/workspace/mlops/tests/usecase/notebook/test_notebook_loader.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.venv/lib/python3.12/site-packages/_pytest/python.py:507: in importtestmodule
+    mod = import_path(
+.venv/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:197: in exec_module
+    exec(co, module.__dict__)
+tests/usecase/notebook/test_notebook_loader.py:19: in <module>
+    from src.usecase.notebook.notebook_loader import load_notebook_recipe_cfg
+E   ModuleNotFoundError: No module named 'src.usecase.notebook.notebook_loader'
+=========================== short test summary info ============================
+ERROR tests/usecase/notebook/test_notebook_loader.py
+!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
+=============================== 1 error in 0.08s ===============================

--- a/src/presentation/runners.py
+++ b/src/presentation/runners.py
@@ -328,13 +328,20 @@ def run_pipeline(cfg: DictConfig, logger: Any = None) -> None:
 
 
 def run_push_notebook(cfg: DictConfig, logger: Any = None) -> None:
-    """Notebook push UseCase を実行する。"""
+    """Notebook push UseCase を実行する。
+
+    conf/usecase/push_notebook.yaml は routing-only のため、
+    cfg.recipe が指定されていれば conf/competition/{name}/notebook/{recipe}.yaml を
+    マージしてから実行する（pipeline 経由で notebook が既に dict 指定済みの場合は素通し）。
+    """
+    from src.usecase.notebook.notebook_loader import load_notebook_recipe_cfg
     from src.usecase.notebook.push_notebook import PushNotebookUseCase
 
     if logger is None:
         logger = logging.getLogger(__name__)
+    merged = load_notebook_recipe_cfg(cfg, Path(_CONF_DIR))
     kaggle_api = authenticate_kaggle_api()
-    result = PushNotebookUseCase(cfg=cfg, platform_api=kaggle_api).execute()
+    result = PushNotebookUseCase(cfg=merged, platform_api=kaggle_api).execute()
     logger.info(f"Notebook push 完了: notebook={result.notebook_path}")
 
 

--- a/src/usecase/notebook/notebook_loader.py
+++ b/src/usecase/notebook/notebook_loader.py
@@ -1,0 +1,50 @@
+"""
+notebook 設定の検出・ロードユーティリティ。
+
+conf/competition/{name}/notebook/ 配下の yaml を検出し、
+Hydra cfg とマージした DictConfig を返す。
+
+push_notebook usecase yaml は routing-only（usecase, output_dir のみ）にしているため、
+直接 CLI 実行時（pipeline 経由でない場合）は cfg.recipe から competition 固有の
+notebook 設定（competition, kernel_slug, src_dataset 等）をこのモジュールでロードする。
+pipeline 経由（step で notebook: を直接 dict 指定）の場合は recipe が無いため、
+cfg をそのまま返す（既存の pipeline 実行を壊さない）。
+"""
+
+from pathlib import Path
+
+from omegaconf import DictConfig, OmegaConf
+
+
+def load_notebook_recipe_cfg(cfg: DictConfig, conf_dir: Path) -> DictConfig:
+    """competition の notebook yaml をロードして cfg とマージした設定を返す。
+
+    Args:
+        cfg: Hydra の全体設定（competition.name が必要）。
+             cfg.recipe が指定されていれば該当 yaml をマージする。
+        conf_dir: conf/ ルートディレクトリ。
+
+    Returns:
+        notebook 設定をマージした DictConfig。recipe 未指定時は cfg をそのまま返す。
+
+    Raises:
+        ValueError: recipe を指定したが該当 yaml が見つからない場合。
+    """
+    recipe: str | None = cfg.get("recipe")
+    if recipe is None:
+        return cfg
+
+    competition_name: str = cfg.competition.name
+    notebook_dir = conf_dir / "competition" / competition_name / "notebook"
+    target = notebook_dir / f"{recipe}.yaml"
+    if not target.exists():
+        available = [f.stem for f in sorted(notebook_dir.glob("*.yaml"))]
+        raise ValueError(
+            f"recipe='{recipe}' が見つかりません"
+            f"（competition: {competition_name}）。"
+            f" 利用可能: {available}"
+        )
+
+    # Hydra の struct モード制約を回避するため to_container で plain dict に変換してからマージ
+    base = OmegaConf.create(OmegaConf.to_container(cfg, resolve=True))
+    return DictConfig(OmegaConf.merge(base, OmegaConf.load(target)))

--- a/tests/usecase/notebook/test_notebook_loader.py
+++ b/tests/usecase/notebook/test_notebook_loader.py
@@ -1,0 +1,83 @@
+"""
+notebook_loader — push_notebook usecase の competition 固有設定ロードのテスト。
+
+なぜこのテストが必要か:
+  - `conf/usecase/push_notebook.yaml` は routing-only 化したため、
+    `cfg.recipe` から `conf/competition/{name}/notebook/{recipe}.yaml` を
+    読み込んでマージする処理が必要になった。
+  - 既存の `load_pipeline_recipe_cfg` / `load_trainer_cfgs` と同じパターンで実装するため、
+    同じ振る舞い（recipe 未指定時は素通し、存在しない recipe は ValueError）をテストで固定する。
+  - pipeline 経由（step で `notebook:` を直接 dict 指定）の場合は recipe が無いため、
+    cfg をそのまま返すことを保証し、既存の pipeline 実行を壊さないようにする。
+"""
+
+from pathlib import Path
+
+import pytest
+from omegaconf import DictConfig, OmegaConf
+
+from src.usecase.notebook.notebook_loader import load_notebook_recipe_cfg
+
+
+@pytest.fixture
+def conf_dir(tmp_path: Path) -> Path:
+    """competition/titanic/notebook/ に yaml ファイルを持つ仮の conf ディレクトリ。"""
+    notebook_dir = tmp_path / "competition" / "titanic" / "notebook"
+    notebook_dir.mkdir(parents=True)
+    (notebook_dir / "all_after_download.yaml").write_text(
+        "notebook:\n"
+        "  competition: titanic\n"
+        "  kernel_slug: titanic-pipeline\n"
+        "  src_dataset: mlops-pipeline-src\n"
+        "  recipe: all_after_download\n"
+        "  enable_gpu: false\n"
+        "  enable_internet: false\n"
+        "  extra_datasets: []\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def base_cfg() -> DictConfig:
+    return OmegaConf.create(
+        {"competition": {"name": "titanic"}, "usecase": "push_notebook", "output_dir": "notebooks"}
+    )
+
+
+class TestLoadNotebookRecipeCfg:
+    def test_returns_cfg_unchanged_when_recipe_is_none(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """recipe 未指定（pipeline 経由で notebook が既に dict 指定済み）のときは素通しする。"""
+        cfg = DictConfig(
+            OmegaConf.merge(base_cfg, OmegaConf.create({"notebook": {"competition": "titanic"}}))
+        )
+        result = load_notebook_recipe_cfg(cfg, conf_dir)
+        assert result.notebook.competition == "titanic"
+
+    def test_merges_competition_specific_notebook_yaml_when_recipe_specified(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """recipe 指定時は conf/competition/{name}/notebook/{recipe}.yaml をマージする。"""
+        cfg = DictConfig(
+            OmegaConf.merge(base_cfg, OmegaConf.create({"recipe": "all_after_download"}))
+        )
+        result = load_notebook_recipe_cfg(cfg, conf_dir)
+        assert result.notebook.competition == "titanic"
+        assert result.notebook.kernel_slug == "titanic-pipeline"
+
+    def test_raises_when_specified_recipe_not_found(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """存在しない recipe を指定したときは ValueError。"""
+        cfg = DictConfig(OmegaConf.merge(base_cfg, OmegaConf.create({"recipe": "nonexistent"})))
+        with pytest.raises(ValueError, match="nonexistent"):
+            load_notebook_recipe_cfg(cfg, conf_dir)
+
+    def test_base_cfg_keys_are_merged(self, conf_dir: Path, base_cfg: DictConfig) -> None:
+        """base_cfg のキー（output_dir など）がマージ結果に含まれること。"""
+        cfg = DictConfig(
+            OmegaConf.merge(base_cfg, OmegaConf.create({"recipe": "all_after_download"}))
+        )
+        result = load_notebook_recipe_cfg(cfg, conf_dir)
+        assert result.output_dir == "notebooks"

--- a/tests/usecase/pipeline/test_pipeline_validation.py
+++ b/tests/usecase/pipeline/test_pipeline_validation.py
@@ -125,3 +125,36 @@ class TestValidatePipelineConfigs:
             DictConfig({"usecase": "train", "recipe": None}),
         ]
         validate_pipeline_configs(step_configs)
+
+
+class TestHistopathologicFullPipelineNotebookStep:
+    """conf/competition/histopathologic/pipeline/full.yaml の push_notebook step の回帰テスト。
+
+    なぜこのテストが必要か:
+      - 過去、push_notebook step が `notebook: histopathologic_inference`
+        （文字列）として書かれており、PushNotebookUseCase が
+        `cfg.notebook.competition` にアクセスする箇所で AttributeError になる
+        既存バグがあった（テストが無く未実行のため検出されていなかった）。
+      - notebook が dict 形状であり、PushNotebookUseCase が要求するキーを
+        持つことを実 conf ディレクトリで検証し、再発を防ぐ。
+    """
+
+    _REAL_CONF_DIR = Path(__file__).parent.parent.parent.parent / "conf"
+
+    def test_push_notebook_step_resolves_to_dict_with_required_keys(self) -> None:
+        """push_notebook step の cfg.notebook が dict であり必須キーを持つこと。"""
+        pipeline_path = (
+            self._REAL_CONF_DIR / "competition" / "histopathologic" / "pipeline" / "full.yaml"
+        )
+        pipeline_cfg = OmegaConf.merge(
+            OmegaConf.create({"competition": {"name": "histopathologic"}}),
+            OmegaConf.load(pipeline_path),
+        )
+        step_configs = build_step_configs(DictConfig(pipeline_cfg), self._REAL_CONF_DIR)
+        notebook_step = next(c for c in step_configs if c.get("usecase") == "push_notebook")
+        notebook_cfg = notebook_step.notebook
+        assert isinstance(notebook_cfg, DictConfig), (
+            f"notebook が dict 形状でない（文字列のまま渡されている）: {notebook_cfg!r}"
+        )
+        for key in ("competition", "kernel_slug", "src_dataset", "enable_gpu", "enable_internet"):
+            assert key in notebook_cfg, f"notebook 設定に必須キー '{key}' が無い"


### PR DESCRIPTION
## Summary
- `conf/usecase/push_notebook.yaml` / `push_vertex_notebook.yaml` にハードコードされていた `competition: titanic` 等を削除し、routing-only（`usecase`, `output_dir` のみ）にした。competition 固有値は `conf/competition/{slug}/notebook/{recipe}.yaml` に分離し、`recipe=` で選択する。
- `src/usecase/notebook/notebook_loader.py` を新設し、既存の `pipeline_loader.py` / `trainer_loader.py` と同じパターンで recipe yaml を cfg にマージする。
- 姉妹リポジトリ `../bird-clef-2026` で同種の修正（commit `924e863`）を調査したが、usecase yaml を routing-only にしただけでマージ処理が伴っておらず、直接 CLI 実行は実質動作しない状態だった。mlops では `run_push_notebook` に merge 呼び出しを追加し、実際に動作する形で実装した。
- 調査中に発見した既存バグも修正: `conf/competition/histopathologic/pipeline/full.yaml` の push_notebook step が `notebook: histopathologic_inference`（文字列）のまま渡されており、`PushNotebookUseCase` が `cfg.notebook.competition` にアクセスする箇所で `AttributeError` になっていた（テストが無く検出されていなかった）。

## Test plan
- [x] `uv run pytest`（516件 PASS）
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check src/ tests/ --python .venv`
- [x] `uv run python -m src usecase=push_notebook competition=titanic recipe=all_after_download` を実行確認（mock kaggle api）
- [x] `uv run python -m src usecase=push_vertex_notebook competition=titanic recipe=inference_only` を実行確認（mock kaggle api）
- [x] docs/manual/0700_push-notebook.md 記載のコマンドは全て実行確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)