### PR TITLE
refactor: SeedFixer を Protocol として domain 層に抽象化

### DIFF
--- a/docs/tasks/2026/Q2/0625_seed-fixer-protocol/README.md
+++ b/docs/tasks/2026/Q2/0625_seed-fixer-protocol/README.md
@@ -1,0 +1,28 @@
+# SeedFixer を Protocol として domain 層に抽象化
+
+## 背景
+
+`fix_seed()` は `src/infrastructure/trainer/torch_utils/seed.py` に直接実装されており、
+`vision_trainer.py` が PyTorch 固有の実装に直接 import 依存している
+（usecase/infrastructure 境界に Protocol が無い）。
+
+姉妹リポジトリ `../bird-clef-2026` では `src/domain/seed.py`（Protocol）+
+`src/infrastructure/shared/seed.py`（AllSeedFixer 実装）という形で抽象化しており、
+将来 TensorFlow/JAX 等の別フレームワークを使う Trainer を追加する際に
+domain/usecase 層を変更せず Infrastructure 実装を差し替えられる。
+
+## やること
+
+1. `src/domain/model/seed.py` に `SeedFixer` Protocol（`fix(seed: int) -> None`）を定義する
+   （既存の `src/domain/model/trainer.py` の Protocol 定義スタイルに合わせる）。
+2. `src/infrastructure/trainer/torch_utils/seed.py` に `TorchSeedFixer` クラスを追加し、
+   既存の `fix_seed()` 関数をそのまま内部で呼ぶ（後方互換: 関数自体は削除しない。
+   既存テスト `tests/infrastructure/trainer/torch_utils/test_seed.py` を変更しない）。
+3. `vision_trainer.py` で `TorchSeedFixer` を Protocol 越しに使うように変更する。
+4. テスト: `SeedFixer` Protocol を満たすことの確認、`TorchSeedFixer.fix()` が
+   `fix_seed()` と同じ再現性を持つことの確認。
+
+## 対象外（スコープ外）
+
+- LightGBMTrainer 等、PyTorch 以外の trainer への適用（今回は Vision/PyTorch 系のみ）
+- 既存 `fix_seed()` 関数の削除（後方互換のため残す）

--- a/docs/tasks/2026/Q2/0625_seed-fixer-protocol/TEST_LOG_20260625_170002.md
+++ b/docs/tasks/2026/Q2/0625_seed-fixer-protocol/TEST_LOG_20260625_170002.md
@@ -1,0 +1,62 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.5, pytest-9.0.2, pluggy-1.6.0 -- /home/hope/workspace/mlops/.venv/bin/python3
+cachedir: .pytest_cache
+rootdir: /home/hope/workspace/mlops
+configfile: pyproject.toml
+plugins: anyio-4.12.1, cov-7.0.0, hydra-core-1.3.2
+collecting ... collected 0 items / 2 errors
+
+==================================== ERRORS ====================================
+_______________ ERROR collecting tests/domain/model/test_seed.py _______________
+ImportError while importing test module '/home/hope/workspace/mlops/tests/domain/model/test_seed.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.venv/lib/python3.12/site-packages/_pytest/python.py:507: in importtestmodule
+    mod = import_path(
+.venv/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:197: in exec_module
+    exec(co, module.__dict__)
+tests/domain/model/test_seed.py:13: in <module>
+    from src.domain.model.seed import SeedFixer
+E   ModuleNotFoundError: No module named 'src.domain.model.seed'
+_ ERROR collecting tests/infrastructure/trainer/torch_utils/test_torch_seed_fixer.py _
+ImportError while importing test module '/home/hope/workspace/mlops/tests/infrastructure/trainer/torch_utils/test_torch_seed_fixer.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.venv/lib/python3.12/site-packages/_pytest/python.py:507: in importtestmodule
+    mod = import_path(
+.venv/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:197: in exec_module
+    exec(co, module.__dict__)
+tests/infrastructure/trainer/torch_utils/test_torch_seed_fixer.py:13: in <module>
+    from src.infrastructure.trainer.torch_utils.seed import TorchSeedFixer
+E   ImportError: cannot import name 'TorchSeedFixer' from 'src.infrastructure.trainer.torch_utils.seed' (/home/hope/workspace/mlops/src/infrastructure/trainer/torch_utils/seed.py)
+=========================== short test summary info ============================
+ERROR tests/domain/model/test_seed.py
+ERROR tests/infrastructure/trainer/torch_utils/test_torch_seed_fixer.py
+!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
+============================== 2 errors in 0.77s ===============================

--- a/src/domain/model/seed.py
+++ b/src/domain/model/seed.py
@@ -1,0 +1,29 @@
+"""
+SeedFixer Protocol — 乱数シード固定ドメイン。
+
+設計方針:
+  - SeedFixer は Protocol。TorchSeedFixer など具体実装は infrastructure 層に置き、
+    usecase/trainer は Protocol にのみ依存する。
+  - フレームワーク（PyTorch/TensorFlow/JAX 等）を差し替える際、
+    domain/usecase 層を変更せず infrastructure 実装だけを差し替えられるようにする。
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SeedFixer(Protocol):
+    """乱数シード固定の抽象 Protocol。
+
+    TorchSeedFixer など具体実装は infrastructure/trainer/torch_utils/ に置く。
+    """
+
+    def fix(self, seed: int) -> None:
+        """乱数シードを固定する。
+
+        時間計算量: O(1)
+        空間計算量: O(1)
+        """
+        ...

--- a/src/infrastructure/trainer/torch_utils/seed.py
+++ b/src/infrastructure/trainer/torch_utils/seed.py
@@ -27,3 +27,14 @@ def fix_seed(seed: int) -> None:
     np.random.seed(seed)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
+
+
+class TorchSeedFixer:
+    """domain.model.seed.SeedFixer Protocol の PyTorch 実装。
+
+    fix_seed() をそのまま呼ぶ薄いラッパー。usecase/trainer 層が
+    PyTorch 固有の実装に直接依存しないよう Protocol 越しに使う。
+    """
+
+    def fix(self, seed: int) -> None:
+        fix_seed(seed)

--- a/src/infrastructure/trainer/vision_trainer.py
+++ b/src/infrastructure/trainer/vision_trainer.py
@@ -31,6 +31,7 @@ from torch.utils.data import DataLoader
 from torchvision import transforms
 
 from src.domain.model.backbone import BackboneConfig
+from src.domain.model.seed import SeedFixer
 from src.domain.model.trainer import FoldResult, TrainResult
 from src.infrastructure.trainer.error_analysis import write_error_analysis
 from src.infrastructure.trainer.torch_utils.augmentation import (
@@ -42,7 +43,7 @@ from src.infrastructure.trainer.torch_utils.model_builder import (
     build_vision_model,
     save_checkpoint,
 )
-from src.infrastructure.trainer.torch_utils.seed import fix_seed
+from src.infrastructure.trainer.torch_utils.seed import TorchSeedFixer
 from src.infrastructure.trainer.torch_utils.training_loop import run_training_loop
 from src.infrastructure.trainer.torch_utils.validation import validate_training_inputs
 
@@ -55,8 +56,9 @@ class VisionTrainer:
     Trainer Protocol を満たす。
     """
 
-    def __init__(self, cfg: dict[str, Any]) -> None:
+    def __init__(self, cfg: dict[str, Any], seed_fixer: SeedFixer | None = None) -> None:
         self._cfg = cfg
+        self._seed_fixer: SeedFixer = seed_fixer if seed_fixer is not None else TorchSeedFixer()
 
     def fit_folds(
         self,
@@ -163,7 +165,7 @@ class VisionTrainer:
             fold_out = output_dir / f"fold_{fold_idx}"
             fold_out.mkdir(parents=True, exist_ok=True)
 
-            fix_seed(seed)
+            self._seed_fixer.fix(seed)
 
             train_df = pl.read_parquet(fold_dir / "train.parquet")
             valid_df = pl.read_parquet(fold_dir / "test.parquet")

--- a/tests/domain/model/test_seed.py
+++ b/tests/domain/model/test_seed.py
@@ -1,0 +1,22 @@
+"""
+SeedFixer Protocol のテスト。
+
+なぜこのテストが必要か:
+  - fix_seed() は src/infrastructure/trainer/torch_utils/seed.py に直接実装されており、
+    usecase/trainer 層が PyTorch 固有の実装に直接依存していた。
+  - SeedFixer Protocol を domain 層に定義し、TorchSeedFixer がそれを満たすことを保証することで、
+    将来 TensorFlow/JAX 等の別フレームワーク実装に差し替え可能にする。
+"""
+
+from __future__ import annotations
+
+from src.domain.model.seed import SeedFixer
+
+
+class TestSeedFixerProtocol:
+    def test_torch_seed_fixer_satisfies_protocol(self) -> None:
+        """TorchSeedFixer が SeedFixer Protocol を満たすこと。"""
+        from src.infrastructure.trainer.torch_utils.seed import TorchSeedFixer
+
+        fixer: SeedFixer = TorchSeedFixer()
+        assert isinstance(fixer, SeedFixer)

--- a/tests/domain/model/test_seed.py
+++ b/tests/domain/model/test_seed.py
@@ -2,10 +2,10 @@
 SeedFixer Protocol のテスト。
 
 なぜこのテストが必要か:
-  - fix_seed() は src/infrastructure/trainer/torch_utils/seed.py に直接実装されており、
-    usecase/trainer 層が PyTorch 固有の実装に直接依存していた。
-  - SeedFixer Protocol を domain 層に定義し、TorchSeedFixer がそれを満たすことを保証することで、
-    将来 TensorFlow/JAX 等の別フレームワーク実装に差し替え可能にする。
+  - SeedFixer Protocol を domain 層に定義し、fix(seed: int) -> None を満たす
+    任意のオブジェクトが Protocol を満たすことを保証する。
+  - 具体実装（TorchSeedFixer 等）への依存は infrastructure 層のテストで検証する
+    （Clean Architecture: tests/domain は src/infrastructure に依存してはならない）。
 """
 
 from __future__ import annotations
@@ -13,10 +13,13 @@ from __future__ import annotations
 from src.domain.model.seed import SeedFixer
 
 
-class TestSeedFixerProtocol:
-    def test_torch_seed_fixer_satisfies_protocol(self) -> None:
-        """TorchSeedFixer が SeedFixer Protocol を満たすこと。"""
-        from src.infrastructure.trainer.torch_utils.seed import TorchSeedFixer
+class _FakeSeedFixer:
+    def fix(self, seed: int) -> None:
+        pass
 
-        fixer: SeedFixer = TorchSeedFixer()
+
+class TestSeedFixerProtocol:
+    def test_object_with_fix_method_satisfies_protocol(self) -> None:
+        """fix(seed: int) -> None を実装したオブジェクトが Protocol を満たすこと。"""
+        fixer: SeedFixer = _FakeSeedFixer()
         assert isinstance(fixer, SeedFixer)

--- a/tests/infrastructure/trainer/torch_utils/test_torch_seed_fixer.py
+++ b/tests/infrastructure/trainer/torch_utils/test_torch_seed_fixer.py
@@ -1,0 +1,24 @@
+"""
+TorchSeedFixer のテスト。
+
+なぜこのテストが必要か:
+  - SeedFixer Protocol 実装である TorchSeedFixer.fix() が、既存の fix_seed() 関数と
+    同じ再現性を持つことを保証する（後方互換: fix_seed() 自体は削除しない）。
+"""
+
+from __future__ import annotations
+
+import torch
+
+from src.infrastructure.trainer.torch_utils.seed import TorchSeedFixer
+
+
+class TestTorchSeedFixer:
+    def test_fix_gives_torch_reproducibility(self) -> None:
+        """同じ seed で fix() を呼ぶと torch の乱数が再現されること。"""
+        fixer = TorchSeedFixer()
+        fixer.fix(42)
+        a = torch.randn(5)
+        fixer.fix(42)
+        b = torch.randn(5)
+        assert torch.allclose(a, b)

--- a/tests/infrastructure/trainer/torch_utils/test_torch_seed_fixer.py
+++ b/tests/infrastructure/trainer/torch_utils/test_torch_seed_fixer.py
@@ -2,6 +2,7 @@
 TorchSeedFixer のテスト。
 
 なぜこのテストが必要か:
+  - TorchSeedFixer が domain.model.seed.SeedFixer Protocol を満たすことを保証する。
   - SeedFixer Protocol 実装である TorchSeedFixer.fix() が、既存の fix_seed() 関数と
     同じ再現性を持つことを保証する（後方互換: fix_seed() 自体は削除しない）。
 """
@@ -10,10 +11,16 @@ from __future__ import annotations
 
 import torch
 
+from src.domain.model.seed import SeedFixer
 from src.infrastructure.trainer.torch_utils.seed import TorchSeedFixer
 
 
 class TestTorchSeedFixer:
+    def test_satisfies_seed_fixer_protocol(self) -> None:
+        """TorchSeedFixer が SeedFixer Protocol を満たすこと。"""
+        fixer: SeedFixer = TorchSeedFixer()
+        assert isinstance(fixer, SeedFixer)
+
     def test_fix_gives_torch_reproducibility(self) -> None:
         """同じ seed で fix() を呼ぶと torch の乱数が再現されること。"""
         fixer = TorchSeedFixer()


### PR DESCRIPTION
## Summary
- 姉妹リポジトリ `../bird-clef-2026` の SeedFixer Protocol 抽象化パターン（`src/domain/seed.py` + `src/infrastructure/shared/seed.py`）を調査し、mlops の Clean Architecture 構成（`src/domain/model/`）に合わせて導入した。
- `fix_seed()` が `src/infrastructure/trainer/torch_utils/seed.py` に直接実装され、`VisionTrainer` が PyTorch 固有実装に直接 import 依存していたため、`src/domain/model/seed.py` に `SeedFixer` Protocol（`fix(seed: int) -> None`）を定義し、`TorchSeedFixer` がそれを満たすようにした。
- 将来 TensorFlow/JAX 等の別フレームワーク Trainer を追加する際、domain/usecase 層を変更せず infrastructure 実装だけを差し替えられる。
- `fix_seed()` 関数自体は後方互換のため残し、既存テストは無変更。

## Test plan
- [x] `uv run pytest`（513件 PASS）
- [x] `uv run mille check`（アーキテクチャ境界検証: tests/domain が src/infrastructure に依存しないよう Fake 実装でテスト分離）
- [x] `uv run ty check src/ tests/ --python .venv`
- [x] `uv run ruff check . && uv run ruff format --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)