### PR TITLE
refactor: recipe yaml ロードの重複実装を共通化

### DIFF
--- a/docs/tasks/2026/Q2/0625_consolidate-recipe-loaders/README.md
+++ b/docs/tasks/2026/Q2/0625_consolidate-recipe-loaders/README.md
@@ -1,0 +1,36 @@
+# trainer_loader / inference_loader / pipeline_loader / notebook_loader の共通化
+
+## 背景
+
+`conf/competition/{name}/{subdir}/{recipe}.yaml` を Hydra cfg にマージするロジックが
+以下 4 ファイルにほぼ同一実装でコピペされている:
+
+- `src/usecase/training/trainer_loader.py`（recipe 省略時は training/ 配下を全件ロード）
+- `src/usecase/inference/inference_loader.py`（recipe 省略時は inference/ 配下を全件ロード）
+- `src/usecase/preprocessing/pipeline_loader.py`（recipe 省略時は preprocess/ 配下を全件ロード）
+- `src/usecase/pipeline/pipeline_loader.py`（recipe 必須・単一ファイルのみ）
+- `src/usecase/notebook/notebook_loader.py`（recipe 省略時は cfg をそのまま返す・単一ファイル）
+
+3 種類の振る舞い（複数ロード+フォールバック / 単一必須 / 単一省略可）に共通する
+「to_container で struct 回避 → OmegaConf.merge → 見つからなければ利用可能一覧つきエラー」
+を `src/usecase/_recipe.py` に集約し、既存 4 ファイルを薄いラッパーにする。
+
+## やること
+
+1. `src/usecase/_recipe.py` に以下の2関数を実装する:
+   - `load_recipe_cfgs(cfg, subdir, conf_dir, *, fallback_key=None, empty_dir_message=None, label="recipe") -> list[DictConfig]`
+     （trainer_loader / inference_loader / preprocessing.pipeline_loader 用）
+   - `load_single_recipe_cfg(cfg, subdir, conf_dir, *, required=False, required_message=None, label="recipe") -> DictConfig`
+     （usecase/pipeline/pipeline_loader / notebook_loader 用）
+2. 既存 4 ファイルを上記関数を呼ぶだけの薄いラッパーに書き換える。
+   関数名・シグネチャ・公開 API は変更しない（呼び出し側 `src/presentation/runners.py` は無修正）。
+3. エラーメッセージの文言は既存テストが `match=` で検証している部分文字列
+   （"xgboost", "training", "前処理設定が見つかりません" 等）を変えない。
+4. 既存テスト（trainer_loader / preprocessing.pipeline_loader / notebook_loader）は無修正で全て green を維持する。
+5. `inference_loader.py` にはテストが存在しなかったため、このタイミングで追加する
+   （`_recipe.py` の振る舞いを inference 側からも検証する）。
+
+## 対象外（スコープ外）
+
+- 各 usecase の呼び出し側（runners.py）のロジック変更
+- pipeline_loader 以外の usecase への新規 recipe マージ機能の追加

--- a/docs/tasks/2026/Q2/0625_consolidate-recipe-loaders/TEST_LOG_20260625_185156.md
+++ b/docs/tasks/2026/Q2/0625_consolidate-recipe-loaders/TEST_LOG_20260625_185156.md
@@ -1,0 +1,37 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.5, pytest-9.0.2, pluggy-1.6.0 -- /home/hope/workspace/mlops/.venv/bin/python3
+cachedir: .pytest_cache
+rootdir: /home/hope/workspace/mlops
+configfile: pyproject.toml
+plugins: anyio-4.12.1, cov-7.0.0, hydra-core-1.3.2
+collecting ... collected 0 items / 1 error
+
+==================================== ERRORS ====================================
+________________ ERROR collecting tests/usecase/test_recipe.py _________________
+ImportError while importing test module '/home/hope/workspace/mlops/tests/usecase/test_recipe.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.venv/lib/python3.12/site-packages/_pytest/python.py:507: in importtestmodule
+    mod = import_path(
+.venv/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:197: in exec_module
+    exec(co, module.__dict__)
+tests/usecase/test_recipe.py:19: in <module>
+    from src.usecase._recipe import load_recipe_cfgs, load_single_recipe_cfg
+E   ModuleNotFoundError: No module named 'src.usecase._recipe'
+=========================== short test summary info ============================
+ERROR tests/usecase/test_recipe.py
+!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
+=============================== 1 error in 0.28s ===============================

--- a/src/usecase/_recipe.py
+++ b/src/usecase/_recipe.py
@@ -1,0 +1,114 @@
+"""
+recipe yaml の検出・ロード共通ユーティリティ。
+
+conf/competition/{name}/{subdir}/ 配下の yaml を検出し、Hydra cfg とマージする。
+trainer_loader / inference_loader / preprocessing.pipeline_loader /
+pipeline.pipeline_loader / notebook_loader の共通実装をここに集約する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omegaconf import DictConfig, OmegaConf
+
+
+def _merge(cfg: DictConfig, yaml_path: Path) -> DictConfig:
+    """to_container で plain dict に変換してから merge し、Hydra の struct モード制約を回避する。"""
+    base = OmegaConf.create(OmegaConf.to_container(cfg, resolve=True))
+    return DictConfig(OmegaConf.merge(base, OmegaConf.load(yaml_path)))
+
+
+def _not_found_error(label: str, value: str, competition_name: str, target_dir: Path) -> ValueError:
+    available = [f.stem for f in sorted(target_dir.glob("*.yaml"))]
+    return ValueError(
+        f"{label}='{value}' が見つかりません"
+        f"（competition: {competition_name}）。"
+        f" 利用可能: {available}"
+    )
+
+
+def load_recipe_cfgs(
+    cfg: DictConfig,
+    subdir: str,
+    conf_dir: Path,
+    *,
+    fallback_key: str | None = None,
+    empty_dir_message: str | None = None,
+    label: str = "recipe",
+) -> list[DictConfig]:
+    """recipe 指定時は単一 yaml、未指定時は subdir 配下の全 yaml をロードして cfg とマージする。
+
+    Args:
+        cfg: Hydra の全体設定（competition.name が必要）。cfg.recipe を優先して参照する。
+        subdir: conf/competition/{name}/ 配下のサブディレクトリ名（"training" 等）。
+        conf_dir: conf/ ルートディレクトリ。
+        fallback_key: cfg.recipe が未指定のときに参照するレガシーキー名。
+        empty_dir_message: subdir 配下に yaml が無いときのエラーメッセージ。省略時は既定文を使う。
+        label: 見つからないときのエラーメッセージに使うキー名（"recipe" 等）。
+
+    Returns:
+        マージ済み DictConfig のリスト。
+
+    Raises:
+        ValueError: 指定した recipe が見つからない、または subdir が空の場合。
+    """
+    competition_name: str = cfg.competition.name
+    recipe: str | None = cfg.get("recipe")
+    if recipe is None and fallback_key is not None:
+        recipe = cfg.get(fallback_key)
+
+    target_dir = conf_dir / "competition" / competition_name / subdir
+
+    if recipe is not None:
+        target = target_dir / f"{recipe}.yaml"
+        if not target.exists():
+            raise _not_found_error(label, recipe, competition_name, target_dir)
+        yaml_files = [target]
+    else:
+        yaml_files = sorted(target_dir.glob("*.yaml"))
+        if not yaml_files:
+            raise ValueError(empty_dir_message or f"{subdir} 設定が見つかりません: {target_dir}")
+
+    return [_merge(cfg, f) for f in yaml_files]
+
+
+def load_single_recipe_cfg(
+    cfg: DictConfig,
+    subdir: str,
+    conf_dir: Path,
+    *,
+    required: bool = False,
+    required_message: str | None = None,
+    label: str = "recipe",
+) -> DictConfig:
+    """recipe 指定時のみ単一 yaml をロードして cfg とマージする。
+
+    recipe 未指定時は required に応じて raise するか cfg をそのまま返す（passthrough）。
+
+    Args:
+        cfg: Hydra の全体設定（competition.name と recipe を参照する）。
+        subdir: conf/competition/{name}/ 配下のサブディレクトリ名。
+        conf_dir: conf/ ルートディレクトリ。
+        required: True の場合、recipe 未指定時に ValueError を送出する。
+        required_message: required=True かつ recipe 未指定時のエラーメッセージ。
+        label: 見つからないときのエラーメッセージに使うキー名。
+
+    Returns:
+        recipe 指定時はマージ済み DictConfig。未指定・required=False のときは cfg をそのまま返す。
+
+    Raises:
+        ValueError: required=True で recipe 未指定、または指定した recipe が見つからない場合。
+    """
+    recipe: str | None = cfg.get("recipe")
+    if recipe is None:
+        if required:
+            raise ValueError(required_message or f"{subdir} usecase には recipe= が必要です。")
+        return cfg
+
+    competition_name: str = cfg.competition.name
+    target_dir = conf_dir / "competition" / competition_name / subdir
+    target = target_dir / f"{recipe}.yaml"
+    if not target.exists():
+        raise _not_found_error(label, recipe, competition_name, target_dir)
+    return _merge(cfg, target)

--- a/src/usecase/inference/inference_loader.py
+++ b/src/usecase/inference/inference_loader.py
@@ -7,7 +7,9 @@ Hydra cfg とマージした DictConfig リストを返す。
 
 from pathlib import Path
 
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
+
+from src.usecase._recipe import load_recipe_cfgs
 
 
 def load_inference_cfgs(cfg: DictConfig, conf_dir: Path) -> list[DictConfig]:
@@ -24,26 +26,12 @@ def load_inference_cfgs(cfg: DictConfig, conf_dir: Path) -> list[DictConfig]:
     Raises:
         ValueError: recipe が見つからない / inference ディレクトリが空の場合。
     """
-    competition_name: str = cfg.competition.name
-    recipe: str | None = cfg.get("recipe")
-
-    inference_dir = conf_dir / "competition" / competition_name / "inference"
-
-    if recipe is not None:
-        target = inference_dir / f"{recipe}.yaml"
-        if not target.exists():
-            available = [f.stem for f in sorted(inference_dir.glob("*.yaml"))]
-            raise ValueError(
-                f"recipe='{recipe}' が見つかりません"
-                f"（competition: {competition_name}）。"
-                f" 利用可能: {available}"
-            )
-        yaml_files = [target]
-    else:
-        yaml_files = sorted(inference_dir.glob("*.yaml"))
-        if not yaml_files:
-            raise ValueError(f"inference 設定が見つかりません: {inference_dir}")
-
-    # Hydra の struct モード制約を回避するため to_container で plain dict に変換してからマージ
-    base = OmegaConf.create(OmegaConf.to_container(cfg, resolve=True))
-    return [DictConfig(OmegaConf.merge(base, OmegaConf.load(f))) for f in yaml_files]
+    return load_recipe_cfgs(
+        cfg,
+        "inference",
+        conf_dir,
+        empty_dir_message=(
+            f"inference 設定が見つかりません: "
+            f"{conf_dir / 'competition' / cfg.competition.name / 'inference'}"
+        ),
+    )

--- a/src/usecase/notebook/notebook_loader.py
+++ b/src/usecase/notebook/notebook_loader.py
@@ -13,7 +13,9 @@ cfg をそのまま返す（既存の pipeline 実行を壊さない）。
 
 from pathlib import Path
 
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
+
+from src.usecase._recipe import load_single_recipe_cfg
 
 
 def load_notebook_recipe_cfg(cfg: DictConfig, conf_dir: Path) -> DictConfig:
@@ -30,21 +32,4 @@ def load_notebook_recipe_cfg(cfg: DictConfig, conf_dir: Path) -> DictConfig:
     Raises:
         ValueError: recipe を指定したが該当 yaml が見つからない場合。
     """
-    recipe: str | None = cfg.get("recipe")
-    if recipe is None:
-        return cfg
-
-    competition_name: str = cfg.competition.name
-    notebook_dir = conf_dir / "competition" / competition_name / "notebook"
-    target = notebook_dir / f"{recipe}.yaml"
-    if not target.exists():
-        available = [f.stem for f in sorted(notebook_dir.glob("*.yaml"))]
-        raise ValueError(
-            f"recipe='{recipe}' が見つかりません"
-            f"（competition: {competition_name}）。"
-            f" 利用可能: {available}"
-        )
-
-    # Hydra の struct モード制約を回避するため to_container で plain dict に変換してからマージ
-    base = OmegaConf.create(OmegaConf.to_container(cfg, resolve=True))
-    return DictConfig(OmegaConf.merge(base, OmegaConf.load(target)))
+    return load_single_recipe_cfg(cfg, "notebook", conf_dir, required=False)

--- a/src/usecase/pipeline/pipeline_loader.py
+++ b/src/usecase/pipeline/pipeline_loader.py
@@ -7,7 +7,9 @@ Hydra cfg とマージした DictConfig を返す。
 
 from pathlib import Path
 
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
+
+from src.usecase._recipe import load_single_recipe_cfg
 
 
 def load_pipeline_recipe_cfg(cfg: DictConfig, conf_dir: Path) -> DictConfig:
@@ -23,26 +25,13 @@ def load_pipeline_recipe_cfg(cfg: DictConfig, conf_dir: Path) -> DictConfig:
     Raises:
         ValueError: recipe が指定されていない / yaml が見つからない場合。
     """
-    competition_name: str = cfg.competition.name
-    recipe: str | None = cfg.get("recipe")
-
-    pipeline_dir = conf_dir / "competition" / competition_name / "pipeline"
-
-    if recipe is None:
-        raise ValueError(
+    return load_single_recipe_cfg(
+        cfg,
+        "pipeline",
+        conf_dir,
+        required=True,
+        required_message=(
             "pipeline usecase には recipe= が必要です。\n"
             "例: uv run python -m src usecase=pipeline recipe=all_after_download"
-        )
-
-    target = pipeline_dir / f"{recipe}.yaml"
-    if not target.exists():
-        available = [f.stem for f in sorted(pipeline_dir.glob("*.yaml"))]
-        raise ValueError(
-            f"recipe='{recipe}' が見つかりません"
-            f"（competition: {competition_name}）。"
-            f" 利用可能: {available}"
-        )
-
-    # Hydra の struct モード制約を回避するため to_container で plain dict に変換してからマージ
-    base = OmegaConf.create(OmegaConf.to_container(cfg, resolve=True))
-    return DictConfig(OmegaConf.merge(base, OmegaConf.load(target)))
+        ),
+    )

--- a/src/usecase/preprocessing/pipeline_loader.py
+++ b/src/usecase/preprocessing/pipeline_loader.py
@@ -7,7 +7,9 @@ Hydra cfg とマージした DictConfig リストを返す。
 
 from pathlib import Path
 
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
+
+from src.usecase._recipe import load_recipe_cfgs
 
 
 def load_pipeline_cfgs(cfg: DictConfig, conf_dir: Path) -> list[DictConfig]:
@@ -23,27 +25,15 @@ def load_pipeline_cfgs(cfg: DictConfig, conf_dir: Path) -> list[DictConfig]:
     Raises:
         ValueError: pipeline が見つからない / preprocess ディレクトリが空の場合。
     """
-    competition_name: str = cfg.competition.name
     # recipe= を優先し、旧パラメータ pipeline= へのフォールバックで後方互換性を保つ
-    pipeline: str | None = cfg.get("recipe", cfg.get("pipeline"))
-
-    preprocess_dir = conf_dir / "competition" / competition_name / "preprocess"
-
-    if pipeline is not None:
-        target = preprocess_dir / f"{pipeline}.yaml"
-        if not target.exists():
-            available = [f.stem for f in sorted(preprocess_dir.glob("*.yaml"))]
-            raise ValueError(
-                f"pipeline='{pipeline}' が見つかりません"
-                f"（competition: {competition_name}）。"
-                f" 利用可能: {available}"
-            )
-        yaml_files = [target]
-    else:
-        yaml_files = sorted(preprocess_dir.glob("*.yaml"))
-        if not yaml_files:
-            raise ValueError(f"前処理設定が見つかりません: {preprocess_dir}")
-
-    # Hydra の struct モード制約を回避するため to_container で plain dict に変換してからマージ
-    base = OmegaConf.create(OmegaConf.to_container(cfg, resolve=True))
-    return [DictConfig(OmegaConf.merge(base, OmegaConf.load(f))) for f in yaml_files]
+    return load_recipe_cfgs(
+        cfg,
+        "preprocess",
+        conf_dir,
+        fallback_key="pipeline",
+        empty_dir_message=(
+            f"前処理設定が見つかりません: "
+            f"{conf_dir / 'competition' / cfg.competition.name / 'preprocess'}"
+        ),
+        label="pipeline",
+    )

--- a/src/usecase/training/trainer_loader.py
+++ b/src/usecase/training/trainer_loader.py
@@ -7,7 +7,9 @@ Hydra cfg とマージした DictConfig リストを返す。
 
 from pathlib import Path
 
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
+
+from src.usecase._recipe import load_recipe_cfgs
 
 
 def load_trainer_cfgs(cfg: DictConfig, conf_dir: Path) -> list[DictConfig]:
@@ -24,27 +26,15 @@ def load_trainer_cfgs(cfg: DictConfig, conf_dir: Path) -> list[DictConfig]:
     Raises:
         ValueError: trainer が見つからない / training ディレクトリが空の場合。
     """
-    competition_name: str = cfg.competition.name
     # recipe= を優先し、旧パラメータ trainer_name= へのフォールバックで後方互換性を保つ
-    trainer_name: str | None = cfg.get("recipe", cfg.get("trainer_name"))
-
-    training_dir = conf_dir / "competition" / competition_name / "training"
-
-    if trainer_name is not None:
-        target = training_dir / f"{trainer_name}.yaml"
-        if not target.exists():
-            available = [f.stem for f in sorted(training_dir.glob("*.yaml"))]
-            raise ValueError(
-                f"trainer_name='{trainer_name}' が見つかりません"
-                f"（competition: {competition_name}）。"
-                f" 利用可能: {available}"
-            )
-        yaml_files = [target]
-    else:
-        yaml_files = sorted(training_dir.glob("*.yaml"))
-        if not yaml_files:
-            raise ValueError(f"training 設定が見つかりません: {training_dir}")
-
-    # Hydra の struct モード制約を回避するため to_container で plain dict に変換してからマージ
-    base = OmegaConf.create(OmegaConf.to_container(cfg, resolve=True))
-    return [DictConfig(OmegaConf.merge(base, OmegaConf.load(f))) for f in yaml_files]
+    return load_recipe_cfgs(
+        cfg,
+        "training",
+        conf_dir,
+        fallback_key="trainer_name",
+        empty_dir_message=(
+            f"training 設定が見つかりません: "
+            f"{conf_dir / 'competition' / cfg.competition.name / 'training'}"
+        ),
+        label="trainer_name",
+    )

--- a/tests/usecase/inference/test_inference_loader.py
+++ b/tests/usecase/inference/test_inference_loader.py
@@ -1,0 +1,70 @@
+"""
+inference_loader のテスト。
+
+なぜこのテストが必要か:
+  - load_inference_cfgs は conf/competition/{name}/inference/*.yaml を検出し
+    cfg とマージするが、これまでテストが存在せず回帰検知できなかった。
+  - trainer_loader / preprocessing.pipeline_loader と同じ recipe ロードパターンを
+    共通実装（src/usecase/_recipe.py）に委譲しているため、その委譲が正しく
+    機能することをここで固定する。
+"""
+
+from pathlib import Path
+
+import pytest
+from omegaconf import DictConfig, OmegaConf
+
+from src.usecase.inference.inference_loader import load_inference_cfgs
+
+
+@pytest.fixture
+def conf_dir(tmp_path: Path) -> Path:
+    """competition/titanic/inference/ に yaml ファイルを持つ仮の conf ディレクトリ。"""
+    inference_dir = tmp_path / "competition" / "titanic" / "inference"
+    inference_dir.mkdir(parents=True)
+    (inference_dir / "lgbm.yaml").write_text("model: lgbm\n")
+    (inference_dir / "ensemble.yaml").write_text("model: ensemble\n")
+    return tmp_path
+
+
+@pytest.fixture
+def base_cfg() -> DictConfig:
+    return OmegaConf.create({"competition": {"name": "titanic"}, "seed": 42})
+
+
+class TestLoadInferenceCfgs:
+    def test_loads_all_yamls_when_no_recipe_specified(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """recipe 未指定時は inference/ 配下の全 yaml をロードすること。"""
+        cfgs = load_inference_cfgs(base_cfg, conf_dir)
+        models = sorted(c.model for c in cfgs)
+        assert models == ["ensemble", "lgbm"]
+
+    def test_loads_single_yaml_when_recipe_specified(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """recipe=lgbm を指定したときは lgbm.yaml のみロードすること。"""
+        cfg = DictConfig(OmegaConf.merge(base_cfg, OmegaConf.create({"recipe": "lgbm"})))
+        cfgs = load_inference_cfgs(cfg, conf_dir)
+        assert len(cfgs) == 1
+        assert cfgs[0].model == "lgbm"
+
+    def test_raises_when_specified_recipe_not_found(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """存在しない recipe を指定したとき ValueError。"""
+        cfg = DictConfig(OmegaConf.merge(base_cfg, OmegaConf.create({"recipe": "nonexistent"})))
+        with pytest.raises(ValueError, match="nonexistent"):
+            load_inference_cfgs(cfg, conf_dir)
+
+    def test_raises_when_inference_dir_is_empty(self, tmp_path: Path, base_cfg: DictConfig) -> None:
+        """inference ディレクトリが空のとき ValueError。"""
+        (tmp_path / "competition" / "titanic" / "inference").mkdir(parents=True)
+        with pytest.raises(ValueError, match="inference"):
+            load_inference_cfgs(base_cfg, tmp_path)
+
+    def test_base_cfg_keys_are_merged(self, conf_dir: Path, base_cfg: DictConfig) -> None:
+        """base_cfg のキー（seed など）がマージ結果に含まれること。"""
+        cfgs = load_inference_cfgs(base_cfg, conf_dir)
+        assert all(c.seed == 42 for c in cfgs)

--- a/tests/usecase/test_recipe.py
+++ b/tests/usecase/test_recipe.py
@@ -1,0 +1,124 @@
+"""
+src/usecase/_recipe.py の共通 recipe ロードユーティリティのテスト。
+
+なぜこのテストが必要か:
+  - trainer_loader / inference_loader / preprocessing.pipeline_loader /
+    usecase.pipeline.pipeline_loader / notebook_loader が同種の
+    「conf/competition/{name}/{subdir}/{recipe}.yaml を cfg にマージする」
+    ロジックをコピペしていたため、共通実装 load_recipe_cfgs / load_single_recipe_cfg
+    に集約する。各 loader の既存テストは無修正で green を維持するために、
+    フォールバックキー・空ディレクトリ時のメッセージ・必須/省略可の挙動を
+    ここで個別に固定する。
+"""
+
+from pathlib import Path
+
+import pytest
+from omegaconf import DictConfig, OmegaConf
+
+from src.usecase._recipe import load_recipe_cfgs, load_single_recipe_cfg
+
+
+@pytest.fixture
+def conf_dir(tmp_path: Path) -> Path:
+    """competition/titanic/training/ に yaml ファイルを持つ仮の conf ディレクトリ。"""
+    training_dir = tmp_path / "competition" / "titanic" / "training"
+    training_dir.mkdir(parents=True)
+    (training_dir / "lgbm.yaml").write_text("trainer:\n  type: lgbm\n")
+    (training_dir / "nn.yaml").write_text("trainer:\n  type: nn\n")
+    return tmp_path
+
+
+@pytest.fixture
+def base_cfg() -> DictConfig:
+    return OmegaConf.create({"competition": {"name": "titanic"}, "seed": 42})
+
+
+class TestLoadRecipeCfgs:
+    def test_returns_all_yamls_when_recipe_not_specified(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """recipe 未指定時は subdir 配下の全 yaml をロードすること。"""
+        cfgs = load_recipe_cfgs(base_cfg, "training", conf_dir)
+        types = sorted(c.trainer.type for c in cfgs)
+        assert types == ["lgbm", "nn"]
+
+    def test_returns_single_yaml_when_recipe_specified(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """recipe 指定時は該当 yaml のみロードすること。"""
+        cfg = DictConfig(OmegaConf.merge(base_cfg, OmegaConf.create({"recipe": "lgbm"})))
+        cfgs = load_recipe_cfgs(cfg, "training", conf_dir)
+        assert len(cfgs) == 1
+        assert cfgs[0].trainer.type == "lgbm"
+
+    def test_uses_fallback_key_when_recipe_not_specified(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """recipe 未指定だが fallback_key が指定されたとき、それを優先すること。"""
+        cfg = DictConfig(OmegaConf.merge(base_cfg, OmegaConf.create({"trainer_name": "nn"})))
+        cfgs = load_recipe_cfgs(cfg, "training", conf_dir, fallback_key="trainer_name")
+        assert len(cfgs) == 1
+        assert cfgs[0].trainer.type == "nn"
+
+    def test_raises_with_available_list_when_recipe_not_found(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """存在しない recipe を指定したとき利用可能な一覧を含むエラーになること。"""
+        cfg = DictConfig(OmegaConf.merge(base_cfg, OmegaConf.create({"recipe": "xgboost"})))
+        with pytest.raises(ValueError, match="xgboost"):
+            load_recipe_cfgs(cfg, "training", conf_dir)
+
+    def test_raises_custom_empty_dir_message(self, tmp_path: Path, base_cfg: DictConfig) -> None:
+        """ディレクトリが空のとき empty_dir_message が使われること。"""
+        (tmp_path / "competition" / "titanic" / "training").mkdir(parents=True)
+        with pytest.raises(ValueError, match="training 設定が見つかりません"):
+            load_recipe_cfgs(
+                base_cfg,
+                "training",
+                tmp_path,
+                empty_dir_message="training 設定が見つかりません",
+            )
+
+    def test_base_cfg_keys_are_merged(self, conf_dir: Path, base_cfg: DictConfig) -> None:
+        """base_cfg のキー（seed など）がマージ結果に含まれること。"""
+        cfgs = load_recipe_cfgs(base_cfg, "training", conf_dir)
+        assert all(c.seed == 42 for c in cfgs)
+
+
+class TestLoadSingleRecipeCfg:
+    def test_returns_cfg_unchanged_when_recipe_none_and_not_required(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """recipe 未指定・required=False のとき cfg をそのまま返すこと。"""
+        result = load_single_recipe_cfg(base_cfg, "training", conf_dir, required=False)
+        assert result is base_cfg
+
+    def test_raises_when_recipe_none_and_required(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """recipe 未指定・required=True のとき required_message で ValueError になること。"""
+        with pytest.raises(ValueError, match="recipe= が必要です"):
+            load_single_recipe_cfg(
+                base_cfg,
+                "training",
+                conf_dir,
+                required=True,
+                required_message="recipe= が必要です。",
+            )
+
+    def test_loads_single_yaml_when_recipe_specified(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """recipe 指定時は該当 yaml をマージすること。"""
+        cfg = DictConfig(OmegaConf.merge(base_cfg, OmegaConf.create({"recipe": "lgbm"})))
+        result = load_single_recipe_cfg(cfg, "training", conf_dir, required=True)
+        assert result.trainer.type == "lgbm"
+
+    def test_raises_when_specified_recipe_not_found(
+        self, conf_dir: Path, base_cfg: DictConfig
+    ) -> None:
+        """存在しない recipe を指定したとき ValueError。"""
+        cfg = DictConfig(OmegaConf.merge(base_cfg, OmegaConf.create({"recipe": "nonexistent"})))
+        with pytest.raises(ValueError, match="nonexistent"):
+            load_single_recipe_cfg(cfg, "training", conf_dir, required=True)


### PR DESCRIPTION
## Summary
- `trainer_loader` / `inference_loader` / `preprocessing.pipeline_loader` / `pipeline.pipeline_loader` / `notebook_loader` が「`conf/competition/{name}/{subdir}/{recipe}.yaml` を Hydra cfg にマージする」というほぼ同一の実装をコピペしていたため、`src/usecase/_recipe.py` に `load_recipe_cfgs`（複数ロード+フォールバックキー対応）/ `load_single_recipe_cfg`（単一ロード・必須/省略可）として集約した。
- 既存5ファイルの公開API（関数名・シグネチャ）は変更せず、内部実装のみ共通関数を呼ぶ薄いラッパーに置き換えた。呼び出し側（`presentation/runners.py`）は無修正。
- エラーメッセージは既存テストが `match=` で検証している部分文字列（"xgboost", "training", "前処理設定が見つかりません" 等）を維持した。
- `inference_loader.py` にテストが存在しなかったため新規追加した。

## Test plan
- [x] `uv run pytest`（534件 PASS、既存 trainer_loader/preprocessing.pipeline_loader/notebook_loader のテストは無修正で green）
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run ty check src/ tests/ --python .venv`
- [x] `uv run mille check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)