### PR TITLE
feat: 音声コンペ汎用基盤を追加（Phase 1）

### DIFF
--- a/conf/competition/audio_example.yaml
+++ b/conf/competition/audio_example.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+# 音声コンペ用サンプル設定。
+# 実際のコンペ名に置き換えて使う（例: birdclef-2027）。
+competition:
+  name: audio_example

--- a/conf/competition/audio_example/training/efficientnet_b0.yaml
+++ b/conf/competition/audio_example/training/efficientnet_b0.yaml
@@ -6,8 +6,10 @@
 #
 # 前提: preprocess_output_dir に manifest.json と cv_splits.json が存在すること。
 
+usecase: train
 job_id: audio_example_efficientnet_b0
-trainer_type: audio
+trainer:
+  type: audio
 
 spectrogram:
   sample_rate: 32000

--- a/conf/competition/audio_example/training/efficientnet_b0.yaml
+++ b/conf/competition/audio_example/training/efficientnet_b0.yaml
@@ -1,0 +1,35 @@
+# @package _global_
+# AudioTrainer 用サンプル設定（EfficientNet-B0 + SpecAugment + Mixup）。
+#
+# 使い方:
+#   uv run python -m src usecase=train competition=audio_example recipe=efficientnet_b0
+#
+# 前提: preprocess_output_dir に manifest.json と cv_splits.json が存在すること。
+
+job_id: audio_example_efficientnet_b0
+trainer_type: audio
+
+spectrogram:
+  sample_rate: 32000
+  n_fft: 2048
+  hop_length: 512
+  n_mels: 128
+  segment_seconds: 5.0
+
+model:
+  backbone: efficientnet_b0
+  pretrained: true
+  num_classes: 10  # コンペのクラス数に合わせて変更する
+
+training:
+  epochs: 20
+  batch_size: 32
+  lr: 1.0e-3
+  weight_decay: 1.0e-4
+
+augmentation:
+  spec_augment: true
+  mixup: true
+  mixup_alpha: 0.4
+  freq_mask_param: 20
+  time_mask_param: 40

--- a/conf/executor/gcp_vertex.yaml
+++ b/conf/executor/gcp_vertex.yaml
@@ -1,5 +1,8 @@
-# GCP Vertex AI Executor 設定 — 将来実装予定
-# 未実装のため LocalExecutor にフォールバックする
+# GCP Vertex AI Executor 設定 — preprocess ステップでの Vertex 実行は未実装
+#
+# ⚠ この executor_type を preprocess pipeline に設定すると NotImplementedError が発生する。
+# GCP Vertex AI での学習には usecase=remote_train または usecase=vertex_submit を使うこと。
+# 詳細: docs/manual/execution-env.md
 type: gcp_vertex
 project: my-gcp-project
 region: asia-northeast1

--- a/conf/executor/ray_local.yaml
+++ b/conf/executor/ray_local.yaml
@@ -1,5 +1,7 @@
-# RayExecutor（ローカル）設定 — 将来実装予定
-# 未実装のため LocalExecutor にフォールバックする
+# RayExecutor（ローカル）設定 — 未実装
+#
+# ⚠ この executor_type を設定すると NotImplementedError が発生する。
+# ローカル並列実行には executor: local を使用すること。
 type: ray_local
 num_cpus: 4
 num_gpus: 0

--- a/docs/manual/audio-foundation.md
+++ b/docs/manual/audio-foundation.md
@@ -1,0 +1,138 @@
+# 音声コンペ汎用基盤の使い方
+
+## 概要
+
+`src/domain/data/audio.py` と `src/infrastructure/audio/`, `src/infrastructure/trainer/audio_trainer.py` が提供する汎用音声処理基盤の使い方を説明する。
+
+BirdCLEF 2026 の実装から BirdCLEF 固有の部分（Perch embedding / 234-class taxonomy 等）を除いた、音声コンペ全般に使える基盤。
+
+---
+
+## 前提
+
+`soundfile` は `uv sync` で自動インストールされる。追加の手順は不要。
+
+---
+
+## 1. 新しい音声コンペを追加する
+
+### 1-1. competition 設定ファイルを作成する
+
+`conf/competition/<competition_name>.yaml` を作成する。
+
+```yaml
+# conf/competition/birdclef-2027.yaml
+# @package _global_
+competition:
+  name: birdclef-2027
+```
+
+### 1-2. training recipe を作成する
+
+`conf/competition/<competition_name>/training/<recipe_name>.yaml` を作成する。
+`audio_example` のファイルをコピーして編集するのが最も簡単。
+
+```bash
+cp conf/competition/audio_example/training/efficientnet_b0.yaml \
+   conf/competition/birdclef-2027/training/efficientnet_b0.yaml
+```
+
+編集する主なパラメータ:
+
+| キー | 説明 | 例 |
+|---|---|---|
+| `model.num_classes` | 分類クラス数 | `182` |
+| `spectrogram.sample_rate` | サンプリングレート（Hz） | `32000` |
+| `spectrogram.segment_seconds` | 1セグメントの長さ（秒） | `5.0` |
+| `training.epochs` | エポック数 | `30` |
+| `training.batch_size` | バッチサイズ | `32` |
+| `augmentation.spec_augment` | SpecAugment を使うか | `true` |
+| `augmentation.mixup` | Mixup を使うか | `true` |
+
+---
+
+## 2. 前処理出力の形式
+
+`AudioTrainer.fit_folds` は以下の2ファイルを `preprocess_output_dir` から読む。
+
+### manifest.json
+
+```json
+[
+  {"file_path": "path/to/sample_0.pt", "label": [1.0, 0.0, 0.0]},
+  {"file_path": "path/to/sample_1.wav", "label": [0.0, 1.0, 0.0]}
+]
+```
+
+- `file_path` が `.pt` の場合: `torch.load` で読み込む。
+  - 1D テンソル（波形）→ `MelSpectrogramTransformer` で変換する。
+  - 2D テンソル（事前計算済みスペクトログラム）→ そのまま使う。
+- `file_path` が `.wav` 等の場合: on-demand でスペクトログラムに変換する。
+
+### cv_splits.json
+
+```json
+[
+  {"train": [0, 1, 2, 3], "val": [4, 5]},
+  {"train": [4, 5], "val": [0, 1, 2, 3]}
+]
+```
+
+manifest のインデックスで fold を指定する。
+
+---
+
+## 3. 学習を実行する
+
+```bash
+uv run python -m src \
+  usecase=train \
+  competition=birdclef-2027 \
+  recipe=efficientnet_b0
+```
+
+出力先は `cfg.output_dir`（デフォルト: `models/original/birdclef-2027/<timestamp>/`）。
+
+各 fold のモデルは `fold_0/model.pt`, `fold_1/model.pt`, ... に保存される。
+
+チェックポイントには以下が含まれる:
+
+```python
+{
+    "model_state_dict": ...,
+    "backbone": "efficientnet_b0",
+    "num_classes": 182,
+    "spectrogram_config": {...}
+}
+```
+
+---
+
+## 4. SpecAugment / Mixup の設定を変更する
+
+`augmentation` セクションで on/off と強度を調整できる。
+
+```yaml
+augmentation:
+  spec_augment: true
+  freq_mask_param: 20   # 周波数マスクの最大幅（メルバンド数）
+  time_mask_param: 40   # 時間マスクの最大幅（フレーム数）
+  mixup: true
+  mixup_alpha: 0.4      # Beta 分布パラメータ（大きいほど混合比が 0.5 に近づく）
+```
+
+---
+
+## 5. サンプル設定で動作を確認する
+
+実データなしで設定が正しくロードされるか確認するには:
+
+```bash
+uv run python -m src \
+  usecase=train \
+  competition=audio_example \
+  recipe=efficientnet_b0 \
+  --cfg job
+```
+
+`--cfg job` は Hydra の設定ダンプオプション。実際に学習は実行しない。

--- a/docs/manual/execution-env.md
+++ b/docs/manual/execution-env.md
@@ -1,0 +1,132 @@
+# 実行環境の切り替えガイド
+
+## 概要
+
+このプロジェクトの学習処理は以下の環境で実行できる。
+
+| 環境 | usecase | 前提 |
+|------|---------|------|
+| ローカル（CPU） | `usecase=train` | `uv sync` のみ |
+| ローカル（GPU） | `usecase=train` | CUDA 環境 + `uv sync` |
+| GCP Vertex AI（非同期） | `usecase=vertex_submit` | GCP セットアップ済み |
+| GCP Vertex AI（同期） | `usecase=remote_train` | GCP セットアップ済み |
+| AWS | 未実装 | — |
+
+---
+
+## 1. ローカル実行
+
+### 設定
+
+変更する設定ファイル: `conf/config.yaml`
+
+```yaml
+defaults:
+  - competition: titanic   # コンペ名を変更する
+  - usecase: train
+```
+
+コンペ固有の学習レシピ: `conf/competition/{name}/training/{recipe}.yaml`
+
+### 実行コマンド
+
+```bash
+# デフォルトレシピで学習
+uv run python -m src usecase=train competition=titanic
+
+# レシピを指定して学習
+uv run python -m src usecase=train competition=titanic recipe=lgbm
+
+# AudioTrainer を使う例（音声コンペ）
+uv run python -m src usecase=train competition=audio_example recipe=efficientnet_b0
+```
+
+### GPU の自動検出
+
+`uv run python -m src usecase=train ...` 実行時、PyTorch が CUDA を自動検出して GPU を使用する。
+明示的に確認する場合:
+
+```bash
+uv run python -c "import torch; print(torch.cuda.is_available())"
+```
+
+---
+
+## 2. GCP Vertex AI 実行
+
+GCP の初期セットアップは [docs/manual/1000_gcp-initial-setup.md](./1000_gcp-initial-setup.md) を参照。
+
+### 設定
+
+`.env` ファイルに以下を設定する:
+
+```
+GCP_PROJECT=your-project-id
+GCP_REGION=asia-northeast1
+GCP_BUCKET_NAME=your-bucket-name
+```
+
+`conf/cloud/vertex.yaml` で machine_type と container_uri を確認する:
+
+```yaml
+cloud:
+  machine_type: n1-standard-4       # CPU 実行
+  accelerator_type: null            # GPU 使用時: NVIDIA_TESLA_T4
+  accelerator_count: 0              # GPU 使用時: 1
+  container_uri: gcr.io/kaggle-images/python:latest  # CPU
+  # GPU の場合: gcr.io/kaggle-gpu-images/python
+```
+
+### GPU を使う場合の設定変更
+
+`conf/cloud/vertex.yaml` を直接編集するか、CLI で上書きする:
+
+```bash
+# T4 GPU 1枚で実行する例
+uv run python -m src usecase=vertex_submit competition=titanic recipe=lgbm \
+  cloud.machine_type=n1-standard-4-t4 \
+  cloud.accelerator_type=NVIDIA_TESLA_T4 \
+  cloud.accelerator_count=1 \
+  cloud.container_uri=gcr.io/kaggle-gpu-images/python
+```
+
+### 実行コマンド
+
+#### 非同期送信（推奨: ジョブを送信して即終了）
+
+```bash
+uv run python -m src usecase=vertex_submit competition=titanic recipe=lgbm
+```
+
+ジョブIDが返るので、完了後に以下でモデルをダウンロードする:
+
+```bash
+uv run python -m src usecase=vertex_download competition=titanic
+```
+
+#### 同期実行（ジョブ完了まで待機）
+
+```bash
+uv run python -m src usecase=remote_train competition=titanic recipe=lgbm
+```
+
+---
+
+## 3. executor 設定について（preprocess ステップ）
+
+`conf/competition/{name}/preprocess/{recipe}.yaml` に `executor:` を設定できる。
+
+```yaml
+executor:
+  type: local    # 唯一の実装済み設定
+```
+
+`conf/executor/gcp_vertex.yaml` と `conf/executor/ray_local.yaml` は将来用のプレースホルダーであり、
+現在設定すると `NotImplementedError` が発生する。preprocess の分散実行は未実装。
+
+---
+
+## 4. AWS について
+
+AWS での実行は未実装。設計判断: Vertex AI を主要クラウドとし、AWS 対応は需要が生じた時点で検討する。
+現時点では AWS サポートの ADR は作成しない（先行実装を避ける原則）。

--- a/docs/tasks/2026/Q2/0625_audio-foundation/README.md
+++ b/docs/tasks/2026/Q2/0625_audio-foundation/README.md
@@ -1,0 +1,74 @@
+# 音声コンペ汎用基盤の導入（Phase 1）
+
+## 背景
+
+姉妹リポジトリ `bird-clef-2026`（BirdCLEF 2026 で実際に使用）には音声処理の実装が揃っている。
+そのうち BirdCLEF 固有のドメインロジック（鳥の種名・Perch embedding 等）を除いた、
+音声コンペ全般で使える汎用基盤を mlops に移植する。
+
+ユーザーとの相談によりスコープは **Phase 1（汎用基盤のみ）** に確定。
+embedding / Perch / TensorFlow 系（`PerchEmbedder`, `LogitsMapper`,
+`ExtractEmbeddingsUseCase`, `EmbeddingHeadTrainer`, `EmbeddingHeadInferencer`）は対象外。
+
+## スコープ
+
+### 実装対象
+
+| ファイル | 内容 |
+|---|---|
+| `src/domain/data/audio.py` | `AudioSample` dataclass, `AudioLoader` Protocol, `SpectrogramConfig` dataclass, `SpectrogramTransformer` Protocol |
+| `src/infrastructure/audio/soundfile_loader.py` | `SoundfileLoader`（`AudioLoader` 実装） |
+| `src/infrastructure/audio/mel_spectrogram.py` | `MelSpectrogramTransformer`（`SpectrogramTransformer` 実装） |
+| `src/infrastructure/trainer/torch_utils/audio_augmentation.py` | `spec_augment()`, `mixup()`（public 化） |
+| `src/infrastructure/trainer/audio_trainer.py` | `AudioTrainer`（`Trainer` Protocol 実装。backbone/num_classes は cfg 経由） |
+| `pyproject.toml` | `soundfile>=0.12` を dependencies に追加 |
+| `mille.toml` | `src_infrastructure` / `tests_infrastructure` の `external_allow` に `soundfile` を追加 |
+| `conf/competition/audio_example/` | 動作確認用の最小サンプル設定（ダミー、実データ不要） |
+| `docs/manual/audio-foundation.md` | 動かし方マニュアル |
+
+### 対象外（Phase 2 以降）
+
+- Perch embedding / TensorFlow 系
+- BirdCLEF 固有のラベルエンコーディング（`LabelEncoder`, 234-class taxonomy）
+- 推論（`AudioInferencer`）— Phase 1 は学習基盤のみ
+
+## 設計判断
+
+### ドメイン層の命名
+
+`bird-clef-2026/src/domain/data/audio.py` は元々ドメイン固有の命名が混入していないため、
+ほぼそのまま移植する。`SpectrogramConfig` は `bird-clef-2026/src/domain/data/label.py` にあるが、
+ラベル関連クラス（`LabelEncoder`）と同居しているため、mlops では
+`src/domain/data/audio.py` に集約する（ファイル名とクラスの対応を一致させる）。
+
+### AudioTrainer の汎用化
+
+元実装は EfficientNet-B0 固定・234 クラス固定だったが、以下のように cfg 経由にする:
+
+- `model.backbone`: backbone 名（`efficientnet_b0` のみ対応、将来拡張可能なように `_build_audio_model` 関数で分岐）
+- `model.num_classes`: クラス数（デフォルト値なし、必須指定にする）
+- `model.pretrained`: pretrained 重みを使うか
+
+`AudioTrainer.__init__` は `VisionTrainer` と同じ DI パターン
+（`SeedFixer` をコンストラクタで受け取り、デフォルトは `TorchSeedFixer`）に揃える。
+
+### spec_augment / mixup の public 化
+
+`bird-clef-2026` の `_spec_augment` / `_mixup` は private 関数として `audio_trainer.py` 内に
+あったが、mlops では既存の `torch_utils/augmentation.py`（vision 用、albumentations ベース）
+と役割が異なるため、新規ファイル `torch_utils/audio_augmentation.py` に分離し、
+`spec_augment()` / `mixup()` として public 化する。
+
+### サンプル conf
+
+`conf/competition/audio_example/` を新設し、`titanic` / `histopathologic` と同じ構造
+（`{competition}.yaml` + `training/*.yaml`）に揃える。実データは用意せず、設定の形のみ示す。
+
+## 品質ゲート（DoD）
+
+実装完了後、DA レビュー前に以下を実行し、全て clean であることを確認する:
+
+1. `uv run pytest`
+2. `uv run ruff check .` / `uv run ruff format --check .`
+3. `uv run ty check src/ tests/ --python .venv`
+4. `uv run mille check`

--- a/docs/tasks/2026/Q2/0625_audio-foundation/TEST_LOG_20260626_000000.md
+++ b/docs/tasks/2026/Q2/0625_audio-foundation/TEST_LOG_20260626_000000.md
@@ -1,0 +1,62 @@
+============================= test session starts ==============================
+collected 0 items / 5 errors
+
+==================================== ERRORS ====================================
+_______________ ERROR collecting tests/domain/data/test_audio.py _______________
+ImportError while importing test module '/home/hope/workspace/mlops/tests/domain/data/test_audio.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/domain/data/test_audio.py:12: in <module>
+    from src.domain.data.audio import (
+E   ModuleNotFoundError: No module named 'src.domain.data.audio'
+_____ ERROR collecting tests/infrastructure/audio/test_mel_spectrogram.py ______
+ImportError while importing test module '/home/hope/workspace/mlops/tests/infrastructure/audio/test_mel_spectrogram.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/infrastructure/audio/test_mel_spectrogram.py:14: in <module>
+    import soundfile as sf
+E   ModuleNotFoundError: No module named 'soundfile'
+_____ ERROR collecting tests/infrastructure/audio/test_soundfile_loader.py _____
+ImportError while importing test module '/home/hope/workspace/mlops/tests/infrastructure/audio/test_soundfile_loader.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/infrastructure/audio/test_soundfile_loader.py:13: in <module>
+    import soundfile as sf
+E   ModuleNotFoundError: No module named 'soundfile'
+_____ ERROR collecting tests/infrastructure/trainer/test_audio_trainer.py ______
+ImportError while importing test module '/home/hope/workspace/mlops/tests/infrastructure/trainer/test_audio_trainer.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/infrastructure/trainer/test_audio_trainer.py:22: in <module>
+    from src.infrastructure.trainer.audio_trainer import AudioTrainer
+E   ModuleNotFoundError: No module named 'src.infrastructure.trainer.audio_trainer'
+_ ERROR collecting tests/infrastructure/trainer/torch_utils/test_audio_augmentation.py _
+ImportError while importing test module '/home/hope/workspace/mlops/tests/infrastructure/trainer/torch_utils/test_audio_augmentation.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+../../.local/share/uv/python/cpython-3.12.5-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/infrastructure/trainer/torch_utils/test_audio_augmentation.py:13: in <module>
+    from src.infrastructure.trainer.torch_utils.audio_augmentation import mixup, spec_augment
+E   ModuleNotFoundError: No module named 'src.infrastructure.trainer.torch_utils.audio_augmentation'
+=========================== short test summary info ============================
+ERROR tests/domain/data/test_audio.py
+ERROR tests/infrastructure/audio/test_mel_spectrogram.py
+ERROR tests/infrastructure/audio/test_soundfile_loader.py
+ERROR tests/infrastructure/trainer/test_audio_trainer.py
+ERROR tests/infrastructure/trainer/torch_utils/test_audio_augmentation.py
+!!!!!!!!!!!!!!!!!!! Interrupted: 5 errors during collection !!!!!!!!!!!!!!!!!!!!
+============================== 5 errors in 0.84s ===============================

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -1,0 +1,36 @@
+# Backlog
+
+ルール:
+- ID は `TASK-NNN`（3桁ゼロ埋め）で発行し、削除・再利用しない
+- ステータス: `[ ]` 未着手 / `[~]` 進行中 / `[x]` 完了
+- 完了したタスクは削除せず末尾に残す（履歴として機能させる）
+
+---
+
+## 未着手
+
+- [ ] **TASK-001** `AudioTrainer` を `runners.py` に接続する
+  - `conf/competition/audio_example/training/efficientnet_b0.yaml` の `trainer_type: audio` を `trainer.type: audio` に修正
+  - `src/presentation/runners.py` の `run_train` に `elif trainer_type == "audio": trainer = AudioTrainer()` を追加
+  - 回帰テスト追加
+
+- [ ] **TASK-002** chezmoi: `git push -u origin <branch>` を `settings.json` の `permissions.allow` に追加
+  - 副作用: リモートへの push が承認なしで実行される
+  - 追加理由: feature ブランチ push のたびに loop 検出が入る
+  - 拒否時の代替: 現状通り都度承認
+  - 変更先: `~/.local/share/chezmoi/dot_claude/settings.json` → `chezmoi apply`
+
+- [ ] **TASK-003** 実行環境の切り替え設計を整理・ドキュメント化する
+  - local / GCP Vertex（CPU・GPU） / AWS（未実装）の切り替え方を `docs/manual/execution-env.md` にまとめる
+  - `conf/executor/gcp_vertex.yaml` と `conf/cloud/vertex.yaml` の役割の違いを明記
+  - AWS 対応の設計判断（やる/やらない）を ADR に残す
+
+- [ ] **TASK-004** `conf/executor/gcp_vertex.yaml` と `conf/executor/ray_local.yaml` の「フォールバックのみ」状態を解消する
+  - 現状: `ExecutorFactory` がこれらを受け取っても `LocalExecutor` に落ちる
+  - GCP Vertex executor を本実装するか、明示的に「未実装」エラーにするか判断する
+
+---
+
+## 完了
+
+（なし）

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -22,14 +22,10 @@
   - 拒否時の代替: 現状通り都度承認
   - 変更先: `~/.local/share/chezmoi/dot_claude/settings.json` → `chezmoi apply`
 
-- [ ] **TASK-003** 実行環境の切り替え設計を整理・ドキュメント化する
-  - local / GCP Vertex（CPU・GPU） / AWS（未実装）の切り替え方を `docs/manual/execution-env.md` にまとめる
-  - `conf/executor/gcp_vertex.yaml` と `conf/cloud/vertex.yaml` の役割の違いを明記
-  - AWS 対応の設計判断（やる/やらない）を ADR に残す
-
-- [ ] **TASK-004** `conf/executor/gcp_vertex.yaml` と `conf/executor/ray_local.yaml` の「フォールバックのみ」状態を解消する
-  - 現状: `ExecutorFactory` がこれらを受け取っても `LocalExecutor` に落ちる
-  - GCP Vertex executor を本実装するか、明示的に「未実装」エラーにするか判断する
+- [x] **TASK-003** 実行環境の切り替え設計を整理・ドキュメント化する
+  - `docs/manual/execution-env.md` 作成。commit `7d25f9d`
+- [x] **TASK-004** `conf/executor/gcp_vertex.yaml` / `ray_local.yaml` の「フォールバックのみ」状態を解消する
+  - `ExecutorFactory` を変更: NotImplementedError / ValueError を明示的に上げる。commit `7d25f9d`
 
 ---
 

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -9,23 +9,17 @@
 
 ## 未着手
 
-- [x] **TASK-001** `AudioTrainer` を `runners.py` に接続する
-  - `conf/competition/audio_example/training/efficientnet_b0.yaml` の `trainer_type: audio` を `trainer.type: audio` に修正
-  - `src/presentation/runners.py` の `run_train` に `elif trainer_type == "audio": trainer = AudioTrainer()` を追加
-  - 回帰テスト追加
-
-- [x] **TASK-002** chezmoi: BACKLOG.md をセッション開始時に自動注入する Hook を追加
-- [x] **TASK-005** chezmoi: ループ検出しきい値を 40→150 に引き上げ（Stop フック対応後も継続ルール追加）
-- [x] **TASK-006** chezmoi: dot_claude 変更は事前確認不要のルールを追加
-  - 副作用: リモートへの push が承認なしで実行される
-  - 追加理由: feature ブランチ push のたびに loop 検出が入る
-  - 拒否時の代替: 現状通り都度承認
-  - 変更先: `~/.local/share/chezmoi/dot_claude/settings.json` → `chezmoi apply`
-
-- [x] **TASK-003** 実行環境の切り替え設計を整理・ドキュメント化する
-  - `docs/manual/execution-env.md` 作成。commit `7d25f9d`
-- [x] **TASK-004** `conf/executor/gcp_vertex.yaml` / `ray_local.yaml` の「フォールバックのみ」状態を解消する
-  - `ExecutorFactory` を変更: NotImplementedError / ValueError を明示的に上げる。commit `7d25f9d`
+- [ ] **TASK-007** usecase 層からインフラ名（remote / vertex）を除去し mille ルールを追加
+  - **前提**: PR #53 マージ後に新ブランチで対応
+  - **mille**: `src_usecase.name_deny` に `"remote"` を追加（`"vertex"` はすでにある）
+  - **リネーム対象**:
+    - `src/usecase/training/remote_train.py` → `cloud_train.py`
+    - `src/usecase/training/remote_submit.py` → `cloud_submit.py`
+    - `src/usecase/training/remote_download.py` → `cloud_download.py`
+    - `src/presentation/runners.py`: `run_remote_train` → `run_cloud_train`、`run_vertex_submit` → `run_cloud_submit`、`run_vertex_download` → `run_cloud_download`
+    - `src/presentation/registry.py`: キー `"remote_train"` / `"vertex_submit"` / `"vertex_download"` → `"cloud_train"` / `"cloud_submit"` / `"cloud_download"`
+    - `conf/usecase/`: `vertex_submit.yaml`、`vertex_download.yaml`、`vertex_train.yaml`、`create_vertex_models.yaml`、`upload_vertex_models.yaml`、`push_vertex_notebook.yaml` → マージ後に実物確認してリネーム案確定
+  - **参照箇所も含めて全置換**: pipeline.py 内の文字列参照、コメント、テストも対象
 
 ---
 
@@ -33,5 +27,7 @@
 
 - [x] **TASK-001** `AudioTrainer` を `runners.py` に接続する。commit `cbb742a`
 - [x] **TASK-002** chezmoi: `pre-task-estimate.sh` にセッション初回 BACKLOG.md 自動注入を追加。グローバル CLAUDE.md にルール #7 追記。dot_claude commit `411a669` / chezmoi commit `7db8a3f`、両方 push 済。
+- [x] **TASK-003** 実行環境の切り替え設計を整理・ドキュメント化する。`docs/manual/execution-env.md` 作成。commit `7d25f9d`
+- [x] **TASK-004** `conf/executor/gcp_vertex.yaml` / `ray_local.yaml` の「フォールバックのみ」状態を解消する。`ExecutorFactory` を NotImplementedError / ValueError に変更。commit `7d25f9d`
 - [x] **TASK-005** chezmoi: ループ検出しきい値 40→150、Stop フック後継続ルール追加。dot_claude commit `5c16848` / `c2ab994`
 - [x] **TASK-006** chezmoi: dot_claude 変更は事前確認不要のルール追加。dot_claude commit `8f9d564`

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -9,12 +9,14 @@
 
 ## 未着手
 
-- [ ] **TASK-001** `AudioTrainer` を `runners.py` に接続する
+- [x] **TASK-001** `AudioTrainer` を `runners.py` に接続する
   - `conf/competition/audio_example/training/efficientnet_b0.yaml` の `trainer_type: audio` を `trainer.type: audio` に修正
   - `src/presentation/runners.py` の `run_train` に `elif trainer_type == "audio": trainer = AudioTrainer()` を追加
   - 回帰テスト追加
 
-- [ ] **TASK-002** chezmoi: `git push -u origin <branch>` を `settings.json` の `permissions.allow` に追加
+- [x] **TASK-002** chezmoi: BACKLOG.md をセッション開始時に自動注入する Hook を追加
+- [x] **TASK-005** chezmoi: ループ検出しきい値を 40→150 に引き上げ（Stop フック対応後も継続ルール追加）
+- [x] **TASK-006** chezmoi: dot_claude 変更は事前確認不要のルールを追加
   - 副作用: リモートへの push が承認なしで実行される
   - 追加理由: feature ブランチ push のたびに loop 検出が入る
   - 拒否時の代替: 現状通り都度承認
@@ -33,4 +35,7 @@
 
 ## 完了
 
-（なし）
+- [x] **TASK-001** `AudioTrainer` を `runners.py` に接続する。commit `cbb742a`
+- [x] **TASK-002** chezmoi: `pre-task-estimate.sh` にセッション初回 BACKLOG.md 自動注入を追加。グローバル CLAUDE.md にルール #7 追記。dot_claude commit `411a669` / chezmoi commit `7db8a3f`、両方 push 済。
+- [x] **TASK-005** chezmoi: ループ検出しきい値 40→150、Stop フック後継続ルール追加。dot_claude commit `5c16848` / `c2ab994`
+- [x] **TASK-006** chezmoi: dot_claude 変更は事前確認不要のルール追加。dot_claude commit `8f9d564`

--- a/mille.toml
+++ b/mille.toml
@@ -20,7 +20,7 @@ paths = ["src/infrastructure/**"]
 allow = ["src_domain", "src_usecase"]
 dependency_mode = "opt-in"
 external_mode = "opt-in"
-external_allow = ["albumentations", "collections", "dataclasses", "datetime", "email", "google", "json", "kaggle", "lightgbm", "logging", "math", "matplotlib", "numpy", "omegaconf", "os", "pandas", "pathlib", "PIL", "polars", "pytorch_grad_cam", "seaborn", "sklearn", "smtplib", "subprocess", "torch", "torchvision", "typing", "urllib", "yaml", "zipfile"]
+external_allow = ["albumentations", "collections", "dataclasses", "datetime", "email", "google", "json", "kaggle", "lightgbm", "logging", "math", "matplotlib", "numpy", "omegaconf", "os", "pandas", "pathlib", "PIL", "polars", "pytorch_grad_cam", "seaborn", "sklearn", "smtplib", "soundfile", "subprocess", "torch", "torchvision", "typing", "urllib", "yaml", "zipfile"]
 name_deny = ["titanic"]
 
 [[layers]]
@@ -46,7 +46,7 @@ paths = ["tests/infrastructure/**"]
 allow = ["src_domain", "src_infrastructure"]
 dependency_mode = "opt-in"
 external_mode = "opt-in"
-external_allow = ["albumentations", "google", "json", "lightgbm", "math", "numpy", "omegaconf", "pandas", "pathlib", "PIL", "polars", "pytest", "smtplib", "src", "torch", "torchvision", "typing", "unittest", "urllib", "yaml", "zipfile"]
+external_allow = ["albumentations", "google", "json", "lightgbm", "math", "numpy", "omegaconf", "pandas", "pathlib", "PIL", "polars", "pytest", "smtplib", "soundfile", "src", "torch", "torchvision", "typing", "unittest", "urllib", "yaml", "zipfile"]
 
 [[layers]]
 name = "tests_usecase"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "grad-cam>=1.5",
     "Pillow>=10.0",
     "albumentations>=1.3",
+    "soundfile>=0.12",
     "jinja2>=3.1",
     "google-cloud-storage>=2.0",
     "google-cloud-aiplatform>=1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,8 @@ certifi==2026.1.4
     #   httpcore
     #   httpx
     #   requests
+cffi==2.0.0
+    # via soundfile
 charset-normalizer==3.4.4
     # via requests
 click==8.3.1
@@ -187,6 +189,7 @@ numpy==2.4.1
     #   scikit-learn
     #   scipy
     #   seaborn
+    #   soundfile
     #   torchmetrics
     #   torchvision
 nvidia-cublas-cu12==12.8.4.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
@@ -297,6 +300,8 @@ pyasn1==0.6.1
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
+pycparser==3.0 ; implementation_name != 'PyPy'
+    # via cffi
 pydantic==2.12.5
     # via
     #   albumentations
@@ -362,6 +367,8 @@ six==1.17.0
     #   python-dateutil
 sniffio==1.3.1
     # via google-genai
+soundfile==0.14.0
+    # via mlops
 stringzilla==4.6.0
     # via albucore
 sympy==1.14.0
@@ -412,6 +419,7 @@ typing-extensions==4.15.0
     #   pydantic
     #   pydantic-core
     #   pytorch-lightning
+    #   soundfile
     #   torch
     #   typing-inspection
 typing-inspection==0.4.2

--- a/src/domain/data/audio.py
+++ b/src/domain/data/audio.py
@@ -13,7 +13,7 @@ domain 層では numpy/torch 等の外部ライブラリに依存せず、
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 
 @dataclass
@@ -91,13 +91,13 @@ class SpectrogramTransformer(Protocol):
     空間計算量: O(n_mels * n_frames)
     """
 
-    def transform_file(self, file_path: str) -> list[list[float]]:
+    def transform_file(self, file_path: str) -> Any:
         """音声ファイルをスペクトログラムに変換する。
 
         Args:
             file_path: 音声ファイルのパス。
 
         Returns:
-            2D リスト (n_mels x time_frames)。
+            スペクトログラム表現。型は実装依存（torch.Tensor 等）。
         """
         ...

--- a/src/domain/data/audio.py
+++ b/src/domain/data/audio.py
@@ -1,0 +1,103 @@
+"""
+音声データのドメイン定義。
+
+AudioSample dataclass, AudioLoader Protocol, SpectrogramConfig dataclass,
+SpectrogramTransformer Protocol を定義する。
+インフラ実装（soundfile, torch 等）はこれらの Protocol を満たすことで
+usecase から利用可能になる。
+
+domain 層では numpy/torch 等の外部ライブラリに依存せず、
+波形データは list[float]、スペクトログラムは list[list[float]] として保持する。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class AudioSample:
+    """音声サンプルの不変表現。
+
+    Attributes:
+        waveform: 波形データ（-1.0 ~ 1.0 の正規化済み振幅値）。
+        sample_rate: サンプリングレート（Hz）。
+        duration_seconds: 音声の長さ（秒）。
+        file_path: 元の音声ファイルパス。
+    """
+
+    waveform: list[float]
+    sample_rate: int
+    duration_seconds: float
+    file_path: str
+
+
+@runtime_checkable
+class AudioLoader(Protocol):
+    """音声ファイルを読み込む Protocol。
+
+    時間計算量: O(n) — n: 音声サンプル数
+    空間計算量: O(n)
+    """
+
+    def load(self, file_path: str) -> AudioSample:
+        """音声ファイルを読み込み AudioSample を返す。
+
+        Args:
+            file_path: 読み込む音声ファイルのパス。
+
+        Returns:
+            AudioSample: 読み込んだ音声データ。
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class SpectrogramConfig:
+    """メルスペクトログラム生成のパラメータ。
+
+    Attributes:
+        sample_rate: サンプリングレート（Hz）。
+        n_fft: FFT ウィンドウサイズ。
+        hop_length: ホップ長。
+        n_mels: メルフィルタバンク数。
+        segment_seconds: 1セグメントの長さ（秒）。
+    """
+
+    sample_rate: int = 32000
+    n_fft: int = 2048
+    hop_length: int = 512
+    n_mels: int = 128
+    segment_seconds: float = 5.0
+
+    @property
+    def segment_samples(self) -> int:
+        """1セグメントのサンプル数。
+
+        時間計算量: O(1)
+        空間計算量: O(1)
+        """
+        return int(self.sample_rate * self.segment_seconds)
+
+
+@runtime_checkable
+class SpectrogramTransformer(Protocol):
+    """音声ファイルをスペクトログラムに変換する Protocol。
+
+    返り値の型は実装依存（torch.Tensor 等）。domain 層では型を限定しない。
+
+    時間計算量: O(n * n_fft) — n: 音声サンプル数
+    空間計算量: O(n_mels * n_frames)
+    """
+
+    def transform_file(self, file_path: str) -> list[list[float]]:
+        """音声ファイルをスペクトログラムに変換する。
+
+        Args:
+            file_path: 音声ファイルのパス。
+
+        Returns:
+            2D リスト (n_mels x time_frames)。
+        """
+        ...

--- a/src/infrastructure/audio/mel_spectrogram.py
+++ b/src/infrastructure/audio/mel_spectrogram.py
@@ -1,0 +1,204 @@
+"""
+torch + numpy + soundfile によるメルスペクトログラム変換。
+
+torchaudio に依存せず、メルフィルタバンクを numpy で構築し、
+torch.stft で STFT を計算してメルスペクトログラム（dB スケール）を生成する。
+
+時間計算量: O(n * n_fft) — n: 音声サンプル数
+空間計算量: O(n_mels * n_frames)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import torch
+
+from src.domain.data.audio import SpectrogramConfig
+
+
+def _create_mel_filterbank(sr: int, n_fft: int, n_mels: int) -> torch.Tensor:
+    """メルフィルタバンクを作成する。
+
+    Args:
+        sr: サンプリングレート。
+        n_fft: FFT サイズ。
+        n_mels: メルバンド数。
+
+    Returns:
+        (n_mels, n_fft // 2 + 1) の FloatTensor。
+
+    時間計算量: O(n_mels * n_fft)
+    空間計算量: O(n_mels * n_fft)
+    """
+    n_freqs = n_fft // 2 + 1
+
+    def hz_to_mel(hz: float) -> float:
+        return 2595.0 * np.log10(1.0 + hz / 700.0)
+
+    def mel_to_hz(mel: float) -> float:
+        return 700.0 * (10.0 ** (mel / 2595.0) - 1.0)
+
+    mel_low = hz_to_mel(0)
+    mel_high = hz_to_mel(sr / 2)
+    mel_points = np.linspace(mel_low, mel_high, n_mels + 2)
+    hz_points = np.array([mel_to_hz(m) for m in mel_points])
+    bin_points = np.floor((n_fft + 1) * hz_points / sr).astype(int)
+
+    filterbank = np.zeros((n_mels, n_freqs))
+    for i in range(n_mels):
+        left = bin_points[i]
+        center = bin_points[i + 1]
+        right = bin_points[i + 2]
+        for j in range(left, center):
+            if center != left:
+                filterbank[i, j] = (j - left) / (center - left)
+        for j in range(center, right):
+            if right != center:
+                filterbank[i, j] = (right - j) / (right - center)
+
+    return torch.FloatTensor(filterbank)
+
+
+class MelSpectrogramTransformer:
+    """torch + numpy ベースのメルスペクトログラム変換。
+
+    SpectrogramTransformer Protocol（domain）を満たす。
+
+    Attributes:
+        _cfg: スペクトログラム設定。
+        _mel_fb: メルフィルタバンク。
+        _window: ハニング窓。
+    """
+
+    def __init__(self, cfg: SpectrogramConfig) -> None:
+        """変換器を初期化する。
+
+        Args:
+            cfg: メルスペクトログラムのパラメータ。
+
+        時間計算量: O(n_mels * n_fft)
+        空間計算量: O(n_mels * n_fft)
+        """
+        self._cfg = cfg
+        self._mel_fb = _create_mel_filterbank(cfg.sample_rate, cfg.n_fft, cfg.n_mels)
+        self._window = torch.hann_window(cfg.n_fft)
+
+    def transform(self, waveform: torch.Tensor) -> torch.Tensor:
+        """波形をメルスペクトログラム（dB）に変換する。
+
+        segment_seconds 未満の音声はゼロパディング、超える音声はトランケートされる。
+
+        Args:
+            waveform: 1D テンソル（samples,）。
+
+        Returns:
+            2D テンソル（n_mels, time_frames）。
+
+        時間計算量: O(n * n_fft)
+        空間計算量: O(n_mels * n_frames)
+        """
+        target_len = self._cfg.segment_samples
+        if waveform.shape[0] < target_len:
+            waveform = torch.nn.functional.pad(waveform, (0, target_len - waveform.shape[0]))
+        elif waveform.shape[0] > target_len:
+            waveform = waveform[:target_len]
+
+        spec = torch.stft(
+            waveform,
+            n_fft=self._cfg.n_fft,
+            hop_length=self._cfg.hop_length,
+            window=self._window,
+            return_complex=True,
+        )
+        power = spec.abs() ** 2
+
+        mel = self._mel_fb @ power
+
+        mel_db = 10.0 * torch.log10(torch.clamp(mel, min=1e-10))
+        top_db = 80.0
+        mel_db = torch.clamp(mel_db, min=mel_db.max() - top_db)
+
+        return mel_db
+
+    def segment_and_transform(self, waveform: torch.Tensor) -> list[torch.Tensor]:
+        """長い音声を segment_seconds 単位に分割してそれぞれ変換する。
+
+        Args:
+            waveform: 1D テンソル。
+
+        Returns:
+            各セグメントのメルスペクトログラムのリスト。
+
+        時間計算量: O(n * n_fft) — n: 全サンプル数
+        空間計算量: O(S * n_mels * n_frames) — S: セグメント数
+        """
+        seg_len = self._cfg.segment_samples
+        total = waveform.shape[0]
+
+        segments = []
+        start = 0
+        while start < total:
+            end = start + seg_len
+            chunk = waveform[start:end]
+            segments.append(self.transform(chunk))
+            start = end
+
+        return segments
+
+    def _load_waveform(self, file_path: str) -> torch.Tensor:
+        """音声ファイルから波形テンソルを読み込む。
+
+        サンプリングレートが cfg と異なる場合は線形補間でリサンプルする。
+
+        時間計算量: O(n)
+        空間計算量: O(n)
+        """
+        data, sr = sf.read(file_path, dtype="float32")
+
+        if data.ndim > 1:
+            data = data.mean(axis=1)
+
+        waveform = torch.from_numpy(data)
+
+        if sr != self._cfg.sample_rate:
+            ratio = self._cfg.sample_rate / sr
+            new_len = int(len(waveform) * ratio)
+            waveform = torch.nn.functional.interpolate(
+                waveform.unsqueeze(0).unsqueeze(0),
+                size=new_len,
+                mode="linear",
+                align_corners=False,
+            ).squeeze()
+
+        return waveform
+
+    def transform_file(self, file_path: str | Path) -> torch.Tensor:
+        """音声ファイルを読み込んでメルスペクトログラムに変換する。
+
+        Args:
+            file_path: 音声ファイルのパス。
+
+        Returns:
+            2D テンソル（n_mels, time_frames）。
+
+        時間計算量: O(n * n_fft)
+        空間計算量: O(n_mels * n_frames)
+        """
+        return self.transform(self._load_waveform(str(file_path)))
+
+    def segment_and_transform_file(self, file_path: str | Path) -> list[torch.Tensor]:
+        """音声ファイルを segment_seconds 単位に分割してそれぞれ変換する。
+
+        Args:
+            file_path: 音声ファイルのパス。
+
+        Returns:
+            各セグメントのメルスペクトログラムのリスト。
+
+        時間計算量: O(n * n_fft) — n: 全サンプル数
+        空間計算量: O(S * n_mels * n_frames) — S: セグメント数
+        """
+        return self.segment_and_transform(self._load_waveform(str(file_path)))

--- a/src/infrastructure/audio/soundfile_loader.py
+++ b/src/infrastructure/audio/soundfile_loader.py
@@ -1,0 +1,68 @@
+"""
+soundfile による音声読み込み。
+
+AudioLoader Protocol の実装。WAV/FLAC/OGG 等の音声ファイルを読み込み、
+AudioSample として返す。
+
+時間計算量: O(n) — n: 読み込む音声サンプル数
+空間計算量: O(n)
+"""
+
+from __future__ import annotations
+
+import soundfile as sf
+
+from src.domain.data.audio import AudioSample
+
+
+class SoundfileLoader:
+    """soundfile ライブラリを使った音声読み込み。
+
+    AudioLoader Protocol を満たす。
+    """
+
+    def load(
+        self,
+        file_path: str,
+        offset: float = 0.0,
+        duration: float | None = None,
+    ) -> AudioSample:
+        """音声ファイルを読み込み AudioSample を返す。
+
+        Args:
+            file_path: 音声ファイルのパス。
+            offset: 読み込み開始位置（秒）。
+            duration: 読み込む長さ（秒）。None の場合は全体を読み込む。
+
+        Returns:
+            AudioSample: 読み込んだ音声データ。
+
+        時間計算量: O(n) — n: 読み込む音声サンプル数
+        空間計算量: O(n)
+        """
+        info = sf.info(file_path)
+        sample_rate = info.samplerate
+
+        start_frame = int(offset * sample_rate)
+        frames_to_read = int(duration * sample_rate) if duration is not None else -1
+
+        data, _ = sf.read(
+            file_path,
+            start=start_frame,
+            stop=start_frame + frames_to_read if frames_to_read > 0 else None,
+            dtype="float32",
+            always_2d=False,
+        )
+
+        if data.ndim > 1:
+            data = data.mean(axis=1)
+
+        waveform = data.tolist()
+        actual_duration = len(waveform) / sample_rate
+
+        return AudioSample(
+            waveform=waveform,
+            sample_rate=sample_rate,
+            duration_seconds=actual_duration,
+            file_path=file_path,
+        )

--- a/src/infrastructure/executor/factory.py
+++ b/src/infrastructure/executor/factory.py
@@ -1,14 +1,22 @@
 """
 ExecutorFactory — executor_type 文字列から Executor インスタンスを生成する。
 
-未実装 Executor が指定された場合は LocalExecutor にフォールバックし、
-呼び出し元が fallback フラグを確認できるよう build_with_fallback() を提供する。
+未実装 Executor が指定された場合はサイレントフォールバックせず NotImplementedError を上げる。
+既知だが未実装の型（gcp_vertex / ray_local）と、全く未知の型（タイポ等）は別の例外で区別する。
 """
 
 from src.infrastructure.executor.local import LocalExecutor
 
-# 実装済み Executor のキー一覧
-_IMPLEMENTED_EXECUTORS: set[str] = {"local"}
+# 既知だが未実装の Executor とエラーメッセージ
+_UNIMPLEMENTED_EXECUTORS: dict[str, str] = {
+    "gcp_vertex": (
+        "gcp_vertex executor は preprocess ステップでは未実装です。"
+        " GCP Vertex AI 学習は usecase=remote_train / vertex_submit を使ってください。"
+    ),
+    "ray_local": (
+        "ray_local executor は未実装です。 ローカル実行には executor: local を使用してください。"
+    ),
+}
 
 
 class ExecutorFactory:
@@ -18,7 +26,7 @@ class ExecutorFactory:
     def build(executor_type: str) -> LocalExecutor:
         """executor_type に対応する Executor を返す。
 
-        未実装の場合は LocalExecutor を返す（例外は上げない）。
+        未実装 / 未知の場合は例外を上げる。
         フォールバック有無を知りたい場合は build_with_fallback() を使う。
         """
         executor, _ = ExecutorFactory.build_with_fallback(executor_type)
@@ -29,11 +37,17 @@ class ExecutorFactory:
         """executor_type に対応する Executor と fallback フラグを返す。
 
         Returns:
-            (executor, is_fallback)
-            is_fallback=True の場合、指定 executor は未実装で local に落とした。
+            (executor, is_fallback=False) — local のみ実装済みのため常に False。
+
+        Raises:
+            NotImplementedError: 既知だが未実装の executor_type（gcp_vertex, ray_local）。
+            ValueError: 未知の executor_type（タイポ等）。
         """
         if executor_type == "local":
             return LocalExecutor(), False
-        # 将来: ray_local / gcp_vertex / etc. はここに追加
-        # 未実装の場合は local にフォールバック
-        return LocalExecutor(), True
+        if executor_type in _UNIMPLEMENTED_EXECUTORS:
+            raise NotImplementedError(_UNIMPLEMENTED_EXECUTORS[executor_type])
+        raise ValueError(
+            f"未知の executor_type: {executor_type!r}。"
+            f" 利用可能: ['local']、未実装: {sorted(_UNIMPLEMENTED_EXECUTORS)}"
+        )

--- a/src/infrastructure/trainer/audio_trainer.py
+++ b/src/infrastructure/trainer/audio_trainer.py
@@ -1,0 +1,348 @@
+"""
+AudioTrainer — Trainer Protocol の音声分類モデル実装。
+
+メルスペクトログラム + CNN backbone（既定: EfficientNet-B0）による
+multi-label / multi-class 分類。BCEWithLogitsLoss + macro-averaged ROC-AUC で
+fold ごとに学習する。
+
+入力は前処理 usecase の出力（manifest.json, cv_splits.json）を想定する。
+manifest の各要素は以下の形式:
+    {"file_path": str, "label": list[float]}
+file_path が .pt の場合は torch.load で読み込み、1D（波形）なら
+transformer で変換、2D（事前計算済みメルスペクトログラム）ならそのまま使う。
+.pt 以外（.wav 等）の場合は transformer で on-demand 変換する。
+
+backbone・num_classes は cfg 経由で指定する（ハードコードしない）。
+
+時間計算量: O(F * E * N * C) — F: fold数, E: epoch数, N: サンプル数, C: モデル計算量
+空間計算量: O(P + B * n_mels * n_frames) — P: パラメータ数, B: バッチサイズ
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import OrderedDict
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from sklearn.metrics import roc_auc_score
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+
+from src.domain.data.audio import SpectrogramConfig
+from src.domain.model.seed import SeedFixer
+from src.domain.model.trainer import FoldResult, TrainResult
+from src.infrastructure.audio.mel_spectrogram import MelSpectrogramTransformer
+from src.infrastructure.trainer.torch_utils.audio_augmentation import mixup, spec_augment
+from src.infrastructure.trainer.torch_utils.seed import TorchSeedFixer
+
+logger = logging.getLogger(__name__)
+
+
+class _ManifestDataset(Dataset):
+    """manifest ベースの音声 Dataset。
+
+    事前計算済みスペクトログラム(.pt) を torch.load で読み込む。
+    .pt が波形テンソル（1D）の場合は transformer で変換する。
+    音声ファイル（.wav 等）の場合は transformer で on-demand 変換する。
+
+    時間計算量: __getitem__ は O(1)（事前計算済み .pt）または O(n * n_fft)（音声ファイル）
+    空間計算量: O(n_mels * n_frames) — サンプルあたり
+    """
+
+    def __init__(
+        self,
+        manifest: list[dict[str, Any]],
+        indices: list[int],
+        transformer: MelSpectrogramTransformer | None = None,
+    ) -> None:
+        self._items = [manifest[i] for i in indices]
+        self._transformer = transformer
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __getitem__(self, index: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """スペクトログラムとラベルを返す。
+
+        時間計算量: O(1)（事前計算済み .pt）または O(n * n_fft)（音声ファイル）
+        空間計算量: O(n_mels * n_frames)
+        """
+        item = self._items[index]
+        file_path = item["file_path"]
+
+        if file_path.endswith(".pt"):
+            mel = torch.load(file_path, weights_only=True)
+            if mel.dim() == 1 and self._transformer:
+                mel = self._transformer.transform(mel)
+        else:
+            if self._transformer is None:
+                msg = "transformer required for audio files"
+                raise ValueError(msg)
+            mel = self._transformer.transform_file(file_path)
+
+        if mel.dim() == 2:
+            mel = mel.unsqueeze(0)
+
+        label = torch.tensor(item["label"], dtype=torch.float32)
+        return mel, label
+
+
+def _build_audio_model(
+    backbone: str,
+    num_classes: int,
+    pretrained: bool = True,
+) -> nn.Module:
+    """音声分類モデルを構築する。
+
+    backbone の入力チャネルを 1ch（メルスペクトログラム）に変更し、
+    分類ヘッドを num_classes に設定する。
+
+    Args:
+        backbone: backbone 名。現在 "efficientnet_b0" のみサポート。
+        num_classes: 分類クラス数。
+        pretrained: ImageNet pretrained 重みを使うか。
+
+    Returns:
+        nn.Module: 構築したモデル。
+
+    時間計算量: O(1)
+    空間計算量: O(P) — P: モデルパラメータ数
+    """
+    if backbone == "efficientnet_b0":
+        from torchvision.models import efficientnet_b0
+
+        weights = "IMAGENET1K_V1" if pretrained else None
+        model = efficientnet_b0(weights=weights)
+        old_conv = model.features[0][0]
+        model.features[0][0] = nn.Conv2d(
+            1,
+            old_conv.out_channels,
+            kernel_size=old_conv.kernel_size,
+            stride=old_conv.stride,
+            padding=old_conv.padding,
+            bias=old_conv.bias is not None,
+        )
+        model.classifier[1] = nn.Linear(model.classifier[1].in_features, num_classes)
+        return model
+
+    msg = f"Unknown backbone: {backbone!r}"
+    raise ValueError(msg)
+
+
+def _compute_macro_roc_auc(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """macro-averaged ROC-AUC を計算する。
+
+    true positive がないクラスはスキップする。
+
+    時間計算量: O(C * N) — C: スコア対象クラス数, N: サンプル数
+    空間計算量: O(C * N)
+    """
+    col_sums = y_true.sum(axis=0)
+    scored_cols = np.where(col_sums > 0)[0]
+    if len(scored_cols) == 0:
+        return 0.0
+    return float(
+        roc_auc_score(
+            y_true[:, scored_cols],
+            y_pred[:, scored_cols],
+            average="macro",
+        )
+    )
+
+
+class AudioTrainer:
+    """音声分類モデルの k-fold クロスバリデーション学習器。
+
+    Trainer Protocol を満たす。SeedFixer はコンストラクタで DI し、
+    デフォルトは TorchSeedFixer を使う（VisionTrainer と同じパターン）。
+    """
+
+    def __init__(self, seed_fixer: SeedFixer | None = None) -> None:
+        self._seed_fixer: SeedFixer = seed_fixer if seed_fixer is not None else TorchSeedFixer()
+
+    def fit_folds(
+        self,
+        preprocess_output_dir: Path,
+        output_dir: Path,
+        cfg: dict[str, Any],
+    ) -> TrainResult:
+        """fold ごとに学習し TrainResult を返す。
+
+        時間計算量: O(F * E * N * C)
+        空間計算量: O(P + B * n_mels * n_frames)
+        """
+        timestamp = cfg.get("_timestamp", datetime.now().strftime("%Y%m%dT%H%M%S"))
+        commit_hash: str = cfg.get("_commit_hash", "unknown")
+        job_id: str = cfg.get("job_id", "audio")
+        seed: int = int(cfg.get("seed", 42))
+
+        spec_cfg = cfg.get("spectrogram", {})
+        config = SpectrogramConfig(
+            sample_rate=spec_cfg.get("sample_rate", 32000),
+            n_fft=spec_cfg.get("n_fft", 2048),
+            hop_length=spec_cfg.get("hop_length", 512),
+            n_mels=spec_cfg.get("n_mels", 128),
+            segment_seconds=spec_cfg.get("segment_seconds", 5.0),
+        )
+        transformer = MelSpectrogramTransformer(config)
+
+        model_cfg = cfg.get("model", {})
+        backbone: str = model_cfg.get("backbone", "efficientnet_b0")
+        pretrained: bool = model_cfg.get("pretrained", True)
+        if "num_classes" not in model_cfg:
+            msg = "cfg['model']['num_classes'] は必須です。分類クラス数を指定してください。"
+            raise ValueError(msg)
+        num_classes: int = int(model_cfg["num_classes"])
+
+        train_cfg = cfg.get("training", {})
+        num_epochs: int = int(train_cfg.get("epochs", 20))
+        batch_size: int = int(train_cfg.get("batch_size", 32))
+        lr: float = float(train_cfg.get("lr", 1e-3))
+        weight_decay: float = float(train_cfg.get("weight_decay", 1e-4))
+
+        aug_cfg = cfg.get("augmentation", {})
+        use_spec_augment: bool = bool(aug_cfg.get("spec_augment", False))
+        use_mixup: bool = bool(aug_cfg.get("mixup", False))
+        mixup_alpha: float = float(aug_cfg.get("mixup_alpha", 0.4))
+        freq_mask_param: int = int(aug_cfg.get("freq_mask_param", 20))
+        time_mask_param: int = int(aug_cfg.get("time_mask_param", 40))
+
+        with open(preprocess_output_dir / "manifest.json") as f:
+            manifest = json.load(f)
+        with open(preprocess_output_dir / "cv_splits.json") as f:
+            splits = json.load(f)
+
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        fold_results: list[FoldResult] = []
+
+        for fold_idx, split in enumerate(splits):
+            fold_out = output_dir / f"fold_{fold_idx}"
+            fold_out.mkdir(parents=True, exist_ok=True)
+
+            self._seed_fixer.fix(seed)
+            logger.info("Fold %d/%d", fold_idx, len(splits))
+
+            train_ds = _ManifestDataset(manifest, split["train"], transformer)
+            val_ds = _ManifestDataset(manifest, split["val"], transformer)
+
+            train_loader = DataLoader(
+                train_ds,
+                batch_size=batch_size,
+                shuffle=True,
+                generator=torch.Generator().manual_seed(seed),
+            )
+            val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False)
+
+            model = _build_audio_model(backbone, num_classes, pretrained).to(device)
+            criterion = nn.BCEWithLogitsLoss()
+            optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+
+            best_score = 0.0
+            best_state: OrderedDict[str, torch.Tensor] = OrderedDict()
+            final_train_loss = 0.0
+
+            for epoch in range(num_epochs):
+                model.train()
+                train_loss_sum = 0.0
+                train_count = 0
+                for mel_batch, label_batch in train_loader:
+                    mel_batch, label_batch = mel_batch.to(device), label_batch.to(device)
+                    if use_spec_augment:
+                        mel_batch = spec_augment(
+                            mel_batch,
+                            freq_mask_param=freq_mask_param,
+                            time_mask_param=time_mask_param,
+                        )
+                    if use_mixup:
+                        mel_batch, label_batch = mixup(mel_batch, label_batch, alpha=mixup_alpha)
+                    optimizer.zero_grad()
+                    out = model(mel_batch)
+                    loss = criterion(out, label_batch)
+                    loss.backward()
+                    optimizer.step()
+                    train_loss_sum += loss.item() * mel_batch.size(0)
+                    train_count += mel_batch.size(0)
+
+                final_train_loss = train_loss_sum / max(train_count, 1)
+
+                model.eval()
+                all_preds: list[np.ndarray] = []
+                all_labels: list[np.ndarray] = []
+                with torch.no_grad():
+                    for mel_batch, label_batch in val_loader:
+                        mel_batch = mel_batch.to(device)
+                        out = model(mel_batch)
+                        probs = torch.sigmoid(out).cpu().numpy()
+                        all_preds.append(probs)
+                        all_labels.append(label_batch.numpy())
+
+                y_pred = np.concatenate(all_preds, axis=0)
+                y_true = np.concatenate(all_labels, axis=0)
+
+                val_score = _compute_macro_roc_auc(y_true, y_pred)
+
+                if val_score >= best_score:
+                    best_score = val_score
+                    best_state = OrderedDict({k: v.clone() for k, v in model.state_dict().items()})
+
+                logger.info(
+                    "  Epoch %d/%d: loss=%.4f, roc_auc=%.4f",
+                    epoch + 1,
+                    num_epochs,
+                    final_train_loss,
+                    val_score,
+                )
+
+            model_path = fold_out / "model.pt"
+            torch.save(
+                {
+                    "model_state_dict": best_state,
+                    "backbone": backbone,
+                    "num_classes": num_classes,
+                    "spectrogram_config": {
+                        "sample_rate": config.sample_rate,
+                        "n_fft": config.n_fft,
+                        "hop_length": config.hop_length,
+                        "n_mels": config.n_mels,
+                        "segment_seconds": config.segment_seconds,
+                    },
+                },
+                model_path,
+            )
+
+            oof_path = fold_out / "oof_predictions.npy"
+            np.save(oof_path, y_pred)
+
+            fold_results.append(
+                FoldResult(
+                    fold_idx=fold_idx,
+                    train_score=final_train_loss,
+                    valid_score=best_score,
+                    metric="roc_auc",
+                    model_path=model_path,
+                    oof_path=oof_path,
+                    error_analysis_path=fold_out / "error_analysis.npy",
+                    feature_importance_path=None,
+                    n_train=len(split["train"]),
+                    n_valid=len(split["val"]),
+                )
+            )
+
+        scores = [f.valid_score for f in fold_results]
+        return TrainResult(
+            job_id=job_id,
+            timestamp=timestamp,
+            commit_hash=commit_hash,
+            trainer_type="audio",
+            output_dir=output_dir,
+            fold_results=fold_results,
+            cv_mean_score=float(np.mean(scores)),
+            cv_std_score=float(np.std(scores)),
+            metric="roc_auc",
+            seed=seed,
+        )

--- a/src/infrastructure/trainer/audio_trainer.py
+++ b/src/infrastructure/trainer/audio_trainer.py
@@ -137,13 +137,15 @@ def _build_audio_model(
 def _compute_macro_roc_auc(y_true: np.ndarray, y_pred: np.ndarray) -> float:
     """macro-averaged ROC-AUC を計算する。
 
-    true positive がないクラスはスキップする。
+    全陰性（col_sum == 0）および全陽性（col_sum == n_samples）のクラスは
+    sklearn が ValueError を送出するためスキップする。
 
     時間計算量: O(C * N) — C: スコア対象クラス数, N: サンプル数
     空間計算量: O(C * N)
     """
+    n_samples = y_true.shape[0]
     col_sums = y_true.sum(axis=0)
-    scored_cols = np.where(col_sums > 0)[0]
+    scored_cols = np.where((col_sums > 0) & (col_sums < n_samples))[0]
     if len(scored_cols) == 0:
         return 0.0
     return float(
@@ -318,6 +320,9 @@ class AudioTrainer:
             oof_path = fold_out / "oof_predictions.npy"
             np.save(oof_path, y_pred)
 
+            ea_path = fold_out / "error_analysis.npy"
+            np.save(ea_path, np.stack([y_true, y_pred], axis=0))
+
             fold_results.append(
                 FoldResult(
                     fold_idx=fold_idx,
@@ -326,7 +331,7 @@ class AudioTrainer:
                     metric="roc_auc",
                     model_path=model_path,
                     oof_path=oof_path,
-                    error_analysis_path=fold_out / "error_analysis.npy",
+                    error_analysis_path=ea_path,
                     feature_importance_path=None,
                     n_train=len(split["train"]),
                     n_valid=len(split["val"]),

--- a/src/infrastructure/trainer/torch_utils/audio_augmentation.py
+++ b/src/infrastructure/trainer/torch_utils/audio_augmentation.py
@@ -1,0 +1,74 @@
+"""
+音声スペクトログラム用 Data Augmentation。
+
+spec_augment() / mixup() を提供する。
+
+既存の torch_utils/augmentation.py は画像（PIL/albumentations 前提）の
+augmentation パイプラインを構築するためのモジュールであり、入力形式が
+（H, W, C）の画像であることを前提にしている。
+本モジュールはメルスペクトログラム（n_mels, time_frames を持つテンソル）を
+直接受け取って変換する点で役割が異なるため、独立したファイルに分離する。
+
+時間計算量: spec_augment は O(B * n_masks), mixup は O(B) — B: バッチサイズ
+空間計算量: O(1)（spec_augment は in-place、mixup は入力と同サイズの出力を生成）
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+
+def spec_augment(
+    mel: torch.Tensor,
+    freq_mask_param: int = 20,
+    time_mask_param: int = 40,
+    n_masks: int = 2,
+) -> torch.Tensor:
+    """SpecAugment: 周波数帯 + 時間帯をランダムマスクする。
+
+    Args:
+        mel: (batch, 1, n_mels, time) テンソル。
+        freq_mask_param: 周波数マスクの最大幅。
+        time_mask_param: 時間マスクの最大幅。
+        n_masks: マスクの個数。
+
+    Returns:
+        マスク適用後のテンソル（入力を in-place 変更して返す）。
+
+    時間計算量: O(B * n_masks) — B: バッチサイズ
+    空間計算量: O(1)（in-place）
+    """
+    _, _, n_mels, n_time = mel.shape
+    for _ in range(n_masks):
+        f = torch.randint(0, freq_mask_param + 1, (1,)).item()
+        f0 = torch.randint(0, int(max(n_mels - f, 1)), (1,)).item()
+        mel[:, :, f0 : f0 + f, :] = 0.0
+        t = torch.randint(0, time_mask_param + 1, (1,)).item()
+        t0 = torch.randint(0, int(max(n_time - t, 1)), (1,)).item()
+        mel[:, :, :, t0 : t0 + t] = 0.0
+    return mel
+
+
+def mixup(
+    mel: torch.Tensor, label: torch.Tensor, alpha: float = 0.4
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Mixup: バッチ内の2サンプルを混合する。multi-label 分類に特に有効。
+
+    Args:
+        mel: (batch, 1, n_mels, time)。
+        label: (batch, num_classes)。
+        alpha: Beta 分布のパラメータ。
+
+    Returns:
+        混合後の (mel, label)。
+
+    時間計算量: O(B) — B: バッチサイズ
+    空間計算量: O(B)
+    """
+    lam = np.random.beta(alpha, alpha)
+    batch_size = mel.size(0)
+    perm = torch.randperm(batch_size, device=mel.device)
+    mixed_mel = lam * mel + (1 - lam) * mel[perm]
+    mixed_label = lam * label + (1 - lam) * label[perm]
+    return mixed_mel, mixed_label

--- a/src/infrastructure/trainer/torch_utils/audio_augmentation.py
+++ b/src/infrastructure/trainer/torch_utils/audio_augmentation.py
@@ -39,14 +39,15 @@ def spec_augment(
     時間計算量: O(B * n_masks) — B: バッチサイズ
     空間計算量: O(1)（in-place）
     """
-    _, _, n_mels, n_time = mel.shape
-    for _ in range(n_masks):
-        f = torch.randint(0, freq_mask_param + 1, (1,)).item()
-        f0 = torch.randint(0, int(max(n_mels - f, 1)), (1,)).item()
-        mel[:, :, f0 : f0 + f, :] = 0.0
-        t = torch.randint(0, time_mask_param + 1, (1,)).item()
-        t0 = torch.randint(0, int(max(n_time - t, 1)), (1,)).item()
-        mel[:, :, :, t0 : t0 + t] = 0.0
+    batch_size, _, n_mels, n_time = mel.shape
+    for b in range(batch_size):
+        for _ in range(n_masks):
+            f = torch.randint(0, freq_mask_param + 1, (1,)).item()
+            f0 = torch.randint(0, int(max(n_mels - f, 1)), (1,)).item()
+            mel[b, :, f0 : f0 + f, :] = 0.0
+            t = torch.randint(0, time_mask_param + 1, (1,)).item()
+            t0 = torch.randint(0, int(max(n_time - t, 1)), (1,)).item()
+            mel[b, :, :, t0 : t0 + t] = 0.0
     return mel
 
 

--- a/src/presentation/runners.py
+++ b/src/presentation/runners.py
@@ -155,9 +155,14 @@ def run_train(cfg: DictConfig, logger: Any = None) -> None:
 
             raw_cfg: dict[str, Any] = OmegaConf.to_container(trainer_cfg, resolve=True)  # ty:ignore[invalid-assignment]
             trainer = VisionTrainer(raw_cfg)
+        elif trainer_type == "audio":
+            from src.infrastructure.trainer.audio_trainer import AudioTrainer
+
+            trainer = AudioTrainer()
         else:
             raise ValueError(
-                f"trainer.type='{trainer_type}' は未登録です。 登録済み: ['lgbm', 'vision']"
+                f"trainer.type='{trainer_type}' は未登録です。"
+                " 登録済み: ['lgbm', 'vision', 'audio']"
             )
         train_result = TrainUseCase(trainer_cfg, trainer=trainer, git_repo=git_repo).execute()
         logger.info(

--- a/tests/domain/data/test_audio.py
+++ b/tests/domain/data/test_audio.py
@@ -1,0 +1,129 @@
+"""
+AudioSample / AudioLoader / SpectrogramConfig / SpectrogramTransformer のテスト。
+
+なぜこのテストが必要か:
+- AudioSample が音声データの不変表現として正しくインスタンス化できることを検証する。
+- AudioLoader Protocol を満たす実装が isinstance チェックを通ることを検証する。
+- domain 層が numpy 等の外部ライブラリに依存せず、list[float] で波形を保持することを保証する。
+- SpectrogramConfig のデフォルト値・segment_samples の計算が正しいことを検証する。
+- SpectrogramTransformer Protocol を満たす実装が isinstance チェックを通ることを検証する。
+"""
+
+from src.domain.data.audio import (
+    AudioLoader,
+    AudioSample,
+    SpectrogramConfig,
+    SpectrogramTransformer,
+)
+
+
+class TestAudioSample:
+    """AudioSample dataclass のテスト。"""
+
+    def test_create_audio_sample(self) -> None:
+        """基本的なインスタンス生成ができること。"""
+        sample = AudioSample(
+            waveform=[0.0, 0.5, -0.5, 1.0],
+            sample_rate=32000,
+            duration_seconds=0.000125,
+            file_path="/path/to/audio.wav",
+        )
+        assert sample.waveform == [0.0, 0.5, -0.5, 1.0]
+        assert sample.sample_rate == 32000
+        assert sample.duration_seconds == 0.000125
+        assert sample.file_path == "/path/to/audio.wav"
+
+    def test_empty_waveform(self) -> None:
+        """空の波形でもインスタンス生成できること。"""
+        sample = AudioSample(
+            waveform=[],
+            sample_rate=32000,
+            duration_seconds=0.0,
+            file_path="/path/to/empty.wav",
+        )
+        assert sample.waveform == []
+        assert sample.duration_seconds == 0.0
+
+
+class TestAudioLoaderProtocol:
+    """AudioLoader Protocol のテスト。"""
+
+    def test_protocol_is_runtime_checkable(self) -> None:
+        """AudioLoader が runtime_checkable であること。"""
+
+        class _MockLoader:
+            def load(self, file_path: str) -> AudioSample:
+                return AudioSample(
+                    waveform=[0.0],
+                    sample_rate=32000,
+                    duration_seconds=0.001,
+                    file_path=file_path,
+                )
+
+        loader = _MockLoader()
+        assert isinstance(loader, AudioLoader)
+
+    def test_non_conforming_class_fails_check(self) -> None:
+        """load メソッドを持たないクラスは Protocol を満たさないこと。"""
+
+        class _BadLoader:
+            pass
+
+        assert not isinstance(_BadLoader(), AudioLoader)
+
+
+class TestSpectrogramConfig:
+    """SpectrogramConfig dataclass のテスト。"""
+
+    def test_default_values(self) -> None:
+        """デフォルト値が正しいこと。"""
+        cfg = SpectrogramConfig()
+        assert cfg.sample_rate == 32000
+        assert cfg.n_fft == 2048
+        assert cfg.hop_length == 512
+        assert cfg.n_mels == 128
+        assert cfg.segment_seconds == 5.0
+
+    def test_segment_samples_computed(self) -> None:
+        """segment_samples が sample_rate * segment_seconds であること。"""
+        cfg = SpectrogramConfig(sample_rate=32000, segment_seconds=5.0)
+        assert cfg.segment_samples == 160000
+
+    def test_custom_values(self) -> None:
+        """カスタム値で初期化できること。"""
+        cfg = SpectrogramConfig(
+            sample_rate=16000, n_fft=1024, hop_length=256, n_mels=64, segment_seconds=2.0
+        )
+        assert cfg.sample_rate == 16000
+        assert cfg.segment_samples == 32000
+
+    def test_is_frozen(self) -> None:
+        """frozen dataclass であり属性変更不可であること。"""
+        cfg = SpectrogramConfig()
+        try:
+            cfg.sample_rate = 1  # type: ignore[misc]
+            raised = False
+        except Exception:
+            raised = True
+        assert raised
+
+
+class TestSpectrogramTransformerProtocol:
+    """SpectrogramTransformer Protocol のテスト。"""
+
+    def test_protocol_is_runtime_checkable(self) -> None:
+        """SpectrogramTransformer が runtime_checkable であること。"""
+
+        class _MockTransformer:
+            def transform_file(self, file_path: str) -> list[list[float]]:
+                return [[0.0]]
+
+        assert isinstance(_MockTransformer(), SpectrogramTransformer)
+
+    def test_non_conforming_class_fails_check(self) -> None:
+        """transform_file メソッドを持たないクラスは Protocol を満たさないこと。"""
+
+        class _BadTransformer:
+            pass
+
+        assert not isinstance(_BadTransformer(), SpectrogramTransformer)

--- a/tests/infrastructure/audio/test_mel_spectrogram.py
+++ b/tests/infrastructure/audio/test_mel_spectrogram.py
@@ -74,9 +74,7 @@ class TestMelSpectrogramTransformer:
         result = transformer.transform_file(path)
         assert result.shape[0] == default_cfg.n_mels
 
-    def test_segment_and_transform_splits_audio(
-        self, default_cfg: SpectrogramConfig
-    ) -> None:
+    def test_segment_and_transform_splits_audio(self, default_cfg: SpectrogramConfig) -> None:
         """segment_and_transform が複数セグメントを返すこと。"""
         transformer = MelSpectrogramTransformer(default_cfg)
         # 3セグメント分の音声

--- a/tests/infrastructure/audio/test_mel_spectrogram.py
+++ b/tests/infrastructure/audio/test_mel_spectrogram.py
@@ -1,0 +1,92 @@
+"""
+MelSpectrogramTransformer のテスト。
+
+なぜこのテストが必要か:
+- torchaudio を使わずに numpy + torch で実装したメルスペクトログラムが
+  SpectrogramTransformer Protocol を満たすことを検証する。
+- 出力形状 (n_mels, time_frames) が設定値と整合することを確認する。
+- 短い音声のゼロパディング・長い音声のトランケートが正しく動くことを保証する。
+- segment_and_transform が複数セグメントに分割することを保証する。
+"""
+
+import numpy as np
+import pytest
+import soundfile as sf
+import torch
+
+from src.domain.data.audio import SpectrogramConfig, SpectrogramTransformer
+from src.infrastructure.audio.mel_spectrogram import MelSpectrogramTransformer
+
+
+@pytest.fixture()
+def wav_file(tmp_path):
+    """5秒のサイン波 WAV ファイルを生成する。"""
+    sample_rate = 32000
+    duration = 5.0
+    t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    waveform = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+    path = tmp_path / "test.wav"
+    sf.write(str(path), waveform, sample_rate)
+    return str(path), sample_rate
+
+
+@pytest.fixture()
+def default_cfg() -> SpectrogramConfig:
+    return SpectrogramConfig(
+        sample_rate=32000, n_fft=512, hop_length=128, n_mels=64, segment_seconds=5.0
+    )
+
+
+class TestMelSpectrogramTransformer:
+    def test_implements_spectrogram_transformer_protocol(
+        self, default_cfg: SpectrogramConfig
+    ) -> None:
+        """SpectrogramTransformer Protocol を満たすこと。"""
+        transformer = MelSpectrogramTransformer(default_cfg)
+        assert isinstance(transformer, SpectrogramTransformer)
+
+    def test_transform_output_shape(self, default_cfg: SpectrogramConfig) -> None:
+        """transform の出力形状が (n_mels, *) であること。"""
+        transformer = MelSpectrogramTransformer(default_cfg)
+        waveform = torch.randn(default_cfg.segment_samples)
+        result = transformer.transform(waveform)
+        assert result.shape[0] == default_cfg.n_mels
+        assert result.dim() == 2
+
+    def test_short_audio_zero_padded(self, default_cfg: SpectrogramConfig) -> None:
+        """segment_seconds より短い音声はゼロパディングされること。"""
+        transformer = MelSpectrogramTransformer(default_cfg)
+        short_waveform = torch.randn(1000)  # segment_samples=160000 より短い
+        result = transformer.transform(short_waveform)
+        assert result.shape[0] == default_cfg.n_mels
+
+    def test_long_audio_truncated(self, default_cfg: SpectrogramConfig) -> None:
+        """segment_seconds より長い音声はトランケートされること。"""
+        transformer = MelSpectrogramTransformer(default_cfg)
+        long_waveform = torch.randn(default_cfg.segment_samples * 2)
+        result = transformer.transform(long_waveform)
+        assert result.shape[0] == default_cfg.n_mels
+
+    def test_transform_file(self, wav_file, default_cfg: SpectrogramConfig) -> None:
+        """ファイルからメルスペクトログラムを生成できること。"""
+        path, _ = wav_file
+        transformer = MelSpectrogramTransformer(default_cfg)
+        result = transformer.transform_file(path)
+        assert result.shape[0] == default_cfg.n_mels
+
+    def test_segment_and_transform_splits_audio(
+        self, default_cfg: SpectrogramConfig
+    ) -> None:
+        """segment_and_transform が複数セグメントを返すこと。"""
+        transformer = MelSpectrogramTransformer(default_cfg)
+        # 3セグメント分の音声
+        waveform = torch.randn(default_cfg.segment_samples * 3)
+        segments = transformer.segment_and_transform(waveform)
+        assert len(segments) == 3
+
+    def test_output_is_db_scale(self, default_cfg: SpectrogramConfig) -> None:
+        """出力が dB スケール（有限な値）であること。"""
+        transformer = MelSpectrogramTransformer(default_cfg)
+        waveform = torch.randn(default_cfg.segment_samples)
+        result = transformer.transform(waveform)
+        assert torch.isfinite(result).all()

--- a/tests/infrastructure/audio/test_soundfile_loader.py
+++ b/tests/infrastructure/audio/test_soundfile_loader.py
@@ -1,0 +1,86 @@
+"""
+SoundfileLoader のテスト。
+
+なぜこのテストが必要か:
+- soundfile ライブラリを使った音声読み込みが AudioLoader Protocol を満たすことを検証する。
+- 読み込んだ AudioSample の waveform, sample_rate, duration_seconds が正しいことを確認する。
+- 存在しないファイルの場合に適切なエラーが発生することを保証する。
+- offset/duration による部分読み込みが正しく動作することを保証する。
+"""
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from src.domain.data.audio import AudioLoader, AudioSample
+from src.infrastructure.audio.soundfile_loader import SoundfileLoader
+
+
+@pytest.fixture()
+def wav_file(tmp_path):
+    """テスト用 WAV ファイルを作成する。"""
+    sample_rate = 32000
+    duration = 0.1  # 100ms
+    t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    waveform = np.sin(2 * np.pi * 440 * t).astype(np.float32)  # 440Hz sine
+    path = tmp_path / "test.wav"
+    sf.write(str(path), waveform, sample_rate)
+    return str(path), sample_rate, duration, len(waveform)
+
+
+class TestSoundfileLoader:
+    """SoundfileLoader のテスト。"""
+
+    def test_implements_audio_loader_protocol(self) -> None:
+        """AudioLoader Protocol を満たすこと。"""
+        loader = SoundfileLoader()
+        assert isinstance(loader, AudioLoader)
+
+    def test_load_returns_audio_sample(self, wav_file) -> None:
+        """音声ファイルを読み込んで AudioSample を返すこと。"""
+        path, _, _, _ = wav_file
+        loader = SoundfileLoader()
+        result = loader.load(path)
+        assert isinstance(result, AudioSample)
+
+    def test_load_correct_sample_rate(self, wav_file) -> None:
+        """サンプルレートが正しいこと。"""
+        path, sample_rate, _, _ = wav_file
+        loader = SoundfileLoader()
+        result = loader.load(path)
+        assert result.sample_rate == sample_rate
+
+    def test_load_correct_waveform_length(self, wav_file) -> None:
+        """波形の長さが正しいこと。"""
+        path, _, _, num_samples = wav_file
+        loader = SoundfileLoader()
+        result = loader.load(path)
+        assert len(result.waveform) == num_samples
+
+    def test_load_correct_duration(self, wav_file) -> None:
+        """duration_seconds が概ね正しいこと。"""
+        path, _, duration, _ = wav_file
+        loader = SoundfileLoader()
+        result = loader.load(path)
+        assert abs(result.duration_seconds - duration) < 0.01
+
+    def test_load_correct_file_path(self, wav_file) -> None:
+        """file_path が正しく設定されること。"""
+        path, _, _, _ = wav_file
+        loader = SoundfileLoader()
+        result = loader.load(path)
+        assert result.file_path == path
+
+    def test_load_nonexistent_file_raises(self) -> None:
+        """存在しないファイルで例外が発生すること。"""
+        loader = SoundfileLoader()
+        with pytest.raises(Exception):
+            loader.load("/nonexistent/file.wav")
+
+    def test_load_with_offset_and_duration(self, wav_file) -> None:
+        """オフセットと期間を指定して部分読み込みできること。"""
+        path, sample_rate, _, _ = wav_file
+        loader = SoundfileLoader()
+        result = loader.load(path, offset=0.0, duration=0.05)
+        expected_samples = int(sample_rate * 0.05)
+        assert len(result.waveform) == expected_samples

--- a/tests/infrastructure/executor/test_factory.py
+++ b/tests/infrastructure/executor/test_factory.py
@@ -2,11 +2,14 @@
 ExecutorFactory のテスト。
 
 なぜこのテストが必要か:
-- 未実装 Executor が指定された場合の local へのフォールバックは
-  パイプライン継続性の保証であり、明示的にテストする必要がある。
-- フォールバック発生時は PreprocessResult に executor_fallback=True が
-  記録されることを確認する。
+- local のみ実装済みであり、gcp_vertex / ray_local などの未実装 executor を
+  指定した場合は NotImplementedError を上げることを保証する。
+- 旧挙動（LocalExecutor へのサイレントフォールバック）は廃止。ユーザーが
+  未実装 executor を指定したまま「なぜか local で動いている」状態を防ぐ。
+- 未知の executor_type には ValueError を上げ、タイポ等を早期発見できる。
 """
+
+import pytest
 
 from src.infrastructure.executor.factory import ExecutorFactory
 from src.infrastructure.executor.local import LocalExecutor
@@ -18,14 +21,27 @@ class TestExecutorFactory:
         executor = ExecutorFactory.build(executor_type="local")
         assert isinstance(executor, LocalExecutor)
 
-    def test_unknown_executor_falls_back_to_local(self) -> None:
-        """未実装 Executor 指定時は LocalExecutor にフォールバックすること。"""
-        executor, fallback = ExecutorFactory.build_with_fallback(executor_type="gcp_vertex")
-        assert isinstance(executor, LocalExecutor)
-        assert fallback is True
-
-    def test_known_executor_no_fallback(self) -> None:
+    def test_local_no_fallback(self) -> None:
         """実装済み Executor (local) はフォールバックが False であること。"""
         executor, fallback = ExecutorFactory.build_with_fallback(executor_type="local")
         assert isinstance(executor, LocalExecutor)
         assert fallback is False
+
+    def test_gcp_vertex_raises_not_implemented(self) -> None:
+        """gcp_vertex executor は未実装のため NotImplementedError が発生すること。
+
+        旧挙動（LocalExecutor へのサイレントフォールバック）は廃止。
+        GCP Vertex AI での学習は usecase=remote_train / vertex_submit を使うこと。
+        """
+        with pytest.raises(NotImplementedError, match="gcp_vertex"):
+            ExecutorFactory.build_with_fallback(executor_type="gcp_vertex")
+
+    def test_ray_local_raises_not_implemented(self) -> None:
+        """ray_local executor は未実装のため NotImplementedError が発生すること。"""
+        with pytest.raises(NotImplementedError, match="ray_local"):
+            ExecutorFactory.build_with_fallback(executor_type="ray_local")
+
+    def test_truly_unknown_raises_value_error(self) -> None:
+        """未知の executor_type（タイポ等）には ValueError が発生すること。"""
+        with pytest.raises(ValueError, match="typo_executor"):
+            ExecutorFactory.build_with_fallback(executor_type="typo_executor")

--- a/tests/infrastructure/trainer/test_audio_trainer.py
+++ b/tests/infrastructure/trainer/test_audio_trainer.py
@@ -195,6 +195,65 @@ class TestAudioTrainer:
         checkpoint = torch.load(result.fold_results[0].model_path, weights_only=True)
         assert checkpoint["num_classes"] == 3
 
+    def test_error_analysis_file_written(
+        self, audio_data_dir: Path, train_cfg: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """error_analysis.npy が各 fold に書き出されること。"""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        trainer = AudioTrainer()
+        result = trainer.fit_folds(
+            preprocess_output_dir=audio_data_dir,
+            output_dir=output_dir,
+            cfg=train_cfg,
+        )
+
+        for fold_result in result.fold_results:
+            assert fold_result.error_analysis_path.exists()
+
+    def test_roc_auc_does_not_crash_on_all_positive_class(
+        self, tmp_path: Path, train_cfg: dict[str, Any]
+    ) -> None:
+        """val fold の1クラスが全陽性のときも ROC-AUC がクラッシュしないこと。"""
+        import json
+
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+
+        num_classes = 3
+        manifest = []
+        for i in range(12):
+            label = [0.0] * num_classes
+            label[0] = 1.0  # クラス0は全サンプルが陽性（全陰性クラスはなし）
+            if i < 6:
+                label[1] = 1.0  # クラス1は train 側で陽性
+            audio_path = audio_dir / f"sample_{i}.pt"
+            torch.save(torch.randn(160000), audio_path)
+            manifest.append({"file_path": str(audio_path), "label": label})
+
+        manifest_path = tmp_path / "manifest.json"
+        with open(manifest_path, "w") as f:
+            json.dump(manifest, f)
+
+        # val が [6,12): クラス0が全陽性、クラス1が全陰性 → 両方スキップされるケース
+        splits = [{"train": list(range(6)), "val": list(range(6, 12))}]
+        splits_path = tmp_path / "cv_splits.json"
+        with open(splits_path, "w") as f:
+            json.dump(splits, f)
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        train_cfg["training"]["epochs"] = 1
+
+        trainer = AudioTrainer()
+        result = trainer.fit_folds(
+            preprocess_output_dir=tmp_path,
+            output_dir=output_dir,
+            cfg=train_cfg,
+        )
+        assert isinstance(result, TrainResult)
+
     def test_missing_num_classes_raises(
         self, audio_data_dir: Path, train_cfg: dict[str, Any], tmp_path: Path
     ) -> None:

--- a/tests/infrastructure/trainer/test_audio_trainer.py
+++ b/tests/infrastructure/trainer/test_audio_trainer.py
@@ -1,0 +1,213 @@
+"""
+AudioTrainer のテスト。
+
+なぜこのテストが必要か:
+- 音声分類モデルが Trainer Protocol を満たすことを検証する。
+- メルスペクトログラム入力（1ch）で forward pass が動作することを確認する。
+- BCEWithLogitsLoss + ROC-AUC による multi-label 学習が正しく動くことを保証する。
+- fit_folds が TrainResult を返すことを確認する。
+- cfg 経由で num_classes / backbone を指定できること（BirdCLEF 固有のハードコード除去）を保証する。
+- SeedFixer Protocol 経由で seed 固定されること（caution.md: seed 固定関数の直接呼び出し禁止）を保証する。
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+
+from src.domain.model.seed import SeedFixer
+from src.domain.model.trainer import Trainer, TrainResult
+from src.infrastructure.trainer.audio_trainer import AudioTrainer
+
+
+class _SpySeedFixer:
+    """SeedFixer Protocol を満たすテスト用スパイ。呼び出し回数・引数を記録する。"""
+
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    def fix(self, seed: int) -> None:
+        self.calls.append(seed)
+
+
+@pytest.fixture()
+def audio_data_dir(tmp_path: Path) -> Path:
+    """AudioTrainer 用のテストデータを作成する。
+
+    前処理 usecase の出力（manifest.json, cv_splits.json）と同じ構造を模倣する。
+    """
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+
+    num_classes = 3
+    manifest = []
+    for i in range(12):
+        class_idx = i % num_classes
+        label = [0.0] * num_classes
+        label[class_idx] = 1.0
+        audio_path = audio_dir / f"sample_{i}.pt"
+        # 5秒分のダミー波形を保存（AudioTrainer 内で transform される）
+        torch.save(torch.randn(160000), audio_path)
+        manifest.append({"file_path": str(audio_path), "label": label})
+
+    manifest_path = tmp_path / "manifest.json"
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f)
+
+    splits = [
+        {"train": list(range(6)), "val": list(range(6, 12))},
+        {"train": list(range(6, 12)), "val": list(range(6))},
+    ]
+    splits_path = tmp_path / "cv_splits.json"
+    with open(splits_path, "w") as f:
+        json.dump(splits, f)
+
+    return tmp_path
+
+
+@pytest.fixture()
+def train_cfg() -> dict[str, Any]:
+    """学習設定を返す。num_classes はテストデータ（3クラス）に合わせる。"""
+    return {
+        "job_id": "test_audio",
+        "trainer_type": "audio",
+        "seed": 42,
+        "metric": "roc_auc",
+        "spectrogram": {
+            "sample_rate": 32000,
+            "n_fft": 2048,
+            "hop_length": 512,
+            "n_mels": 128,
+            "segment_seconds": 5.0,
+        },
+        "model": {
+            "backbone": "efficientnet_b0",
+            "pretrained": False,  # テストでは pretrained=False で高速化
+            "num_classes": 3,
+        },
+        "training": {
+            "epochs": 2,
+            "batch_size": 4,
+            "lr": 1e-3,
+            "weight_decay": 1e-4,
+        },
+    }
+
+
+class TestAudioTrainer:
+    """AudioTrainer のテスト。"""
+
+    def test_implements_trainer_protocol(self) -> None:
+        """Trainer Protocol を満たすこと。"""
+        trainer = AudioTrainer()
+        assert isinstance(trainer, Trainer)
+
+    def test_fit_folds_returns_train_result(
+        self, audio_data_dir: Path, train_cfg: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """fit_folds が TrainResult を返すこと。"""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        trainer = AudioTrainer()
+        result = trainer.fit_folds(
+            preprocess_output_dir=audio_data_dir,
+            output_dir=output_dir,
+            cfg=train_cfg,
+        )
+
+        assert isinstance(result, TrainResult)
+        assert result.trainer_type == "audio"
+        assert result.seed == 42
+        assert len(result.fold_results) == 2
+
+    def test_fold_results_have_scores(
+        self, audio_data_dir: Path, train_cfg: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """各 fold の結果にスコアが含まれ、モデルが保存されること。"""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        trainer = AudioTrainer()
+        result = trainer.fit_folds(
+            preprocess_output_dir=audio_data_dir,
+            output_dir=output_dir,
+            cfg=train_cfg,
+        )
+
+        for fold_result in result.fold_results:
+            assert fold_result.valid_score >= 0.0
+            assert fold_result.valid_score <= 1.0
+            assert fold_result.model_path.exists()
+
+    def test_model_checkpoint_saved(
+        self, audio_data_dir: Path, train_cfg: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """モデルチェックポイントが保存され、ロード可能であること。"""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        trainer = AudioTrainer()
+        result = trainer.fit_folds(
+            preprocess_output_dir=audio_data_dir,
+            output_dir=output_dir,
+            cfg=train_cfg,
+        )
+
+        for fold_result in result.fold_results:
+            assert fold_result.model_path.exists()
+            checkpoint = torch.load(fold_result.model_path, weights_only=True)
+            assert "model_state_dict" in checkpoint
+
+    def test_uses_injected_seed_fixer(
+        self, audio_data_dir: Path, train_cfg: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """SeedFixer Protocol 経由で seed が固定されること（fold 数だけ呼ばれる）。"""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        spy = _SpySeedFixer()
+        trainer = AudioTrainer(seed_fixer=spy)
+        trainer.fit_folds(
+            preprocess_output_dir=audio_data_dir,
+            output_dir=output_dir,
+            cfg=train_cfg,
+        )
+
+        assert spy.calls == [42, 42]
+
+    def test_num_classes_from_cfg(
+        self, audio_data_dir: Path, train_cfg: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """num_classes がハードコードでなく cfg から取られること。"""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        train_cfg["model"]["num_classes"] = 3
+
+        trainer = AudioTrainer()
+        result = trainer.fit_folds(
+            preprocess_output_dir=audio_data_dir,
+            output_dir=output_dir,
+            cfg=train_cfg,
+        )
+
+        checkpoint = torch.load(result.fold_results[0].model_path, weights_only=True)
+        assert checkpoint["num_classes"] == 3
+
+    def test_missing_num_classes_raises(
+        self, audio_data_dir: Path, train_cfg: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """num_classes が cfg に無い場合は明確なエラーになること。"""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        del train_cfg["model"]["num_classes"]
+
+        trainer = AudioTrainer()
+        with pytest.raises(ValueError, match="num_classes"):
+            trainer.fit_folds(
+                preprocess_output_dir=audio_data_dir,
+                output_dir=output_dir,
+                cfg=train_cfg,
+            )

--- a/tests/infrastructure/trainer/test_audio_trainer.py
+++ b/tests/infrastructure/trainer/test_audio_trainer.py
@@ -7,7 +7,7 @@ AudioTrainer のテスト。
 - BCEWithLogitsLoss + ROC-AUC による multi-label 学習が正しく動くことを保証する。
 - fit_folds が TrainResult を返すことを確認する。
 - cfg 経由で num_classes / backbone を指定できること（BirdCLEF 固有のハードコード除去）を保証する。
-- SeedFixer Protocol 経由で seed 固定されること（caution.md: seed 固定関数の直接呼び出し禁止）を保証する。
+- SeedFixer Protocol 経由で seed 固定されること（seed 固定関数の直接呼び出し禁止）を保証する。
 """
 
 import json
@@ -17,7 +17,6 @@ from typing import Any
 import pytest
 import torch
 
-from src.domain.model.seed import SeedFixer
 from src.domain.model.trainer import Trainer, TrainResult
 from src.infrastructure.trainer.audio_trainer import AudioTrainer
 

--- a/tests/infrastructure/trainer/torch_utils/test_audio_augmentation.py
+++ b/tests/infrastructure/trainer/torch_utils/test_audio_augmentation.py
@@ -1,0 +1,76 @@
+"""
+audio_augmentation モジュールのテスト。
+
+なぜこのテストが必要か:
+- spec_augment が (batch, 1, n_mels, time) テンソルにマスクを適用することを検証する。
+- mixup が2サンプルを正しく混合し、ラベルも同じ比率でブレンドされることを検証する。
+- 既存の vision 用 augmentation（albumentations ベース）とは独立したモジュールとして
+  動作することを保証する。
+"""
+
+import torch
+
+from src.infrastructure.trainer.torch_utils.audio_augmentation import mixup, spec_augment
+
+
+class TestSpecAugment:
+    """spec_augment のテスト。"""
+
+    def test_output_shape_unchanged(self) -> None:
+        """入力と出力の形状が同じであること。"""
+        batch = torch.randn(4, 1, 128, 312)
+        result = spec_augment(batch, freq_mask_param=10, time_mask_param=20, n_masks=2)
+        assert result.shape == batch.shape
+
+    def test_some_values_zeroed(self) -> None:
+        """マスクが適用されてゼロになる値が存在すること（確率的だが n_masks=1 で高確率）。"""
+        torch.manual_seed(0)
+        batch = torch.ones(2, 1, 128, 312)
+        result = spec_augment(batch, freq_mask_param=10, time_mask_param=10, n_masks=1)
+        assert (result == 0.0).any()
+
+    def test_no_mask_when_params_zero(self) -> None:
+        """freq_mask_param=time_mask_param=0 のときマスクなし（全値が元のまま）。"""
+        batch = torch.ones(2, 1, 64, 100)
+        result = spec_augment(batch, freq_mask_param=0, time_mask_param=0, n_masks=2)
+        assert torch.allclose(result, batch)
+
+    def test_inplace_modification(self) -> None:
+        """spec_augment は入力テンソルを in-place 変更して返すこと。"""
+        batch = torch.ones(2, 1, 64, 100)
+        result = spec_augment(batch)
+        assert result is batch
+
+
+class TestMixup:
+    """mixup のテスト。"""
+
+    def test_output_shapes(self) -> None:
+        """出力の mel とラベルの形状が入力と同じであること。"""
+        mel = torch.randn(4, 1, 128, 312)
+        label = torch.rand(4, 10)
+        mixed_mel, mixed_label = mixup(mel, label, alpha=0.4)
+        assert mixed_mel.shape == mel.shape
+        assert mixed_label.shape == label.shape
+
+    def test_label_values_in_range(self) -> None:
+        """混合後のラベル値が [0, 1] の範囲内であること（元ラベルが 0/1 の場合）。"""
+        torch.manual_seed(0)
+        mel = torch.randn(8, 1, 128, 312)
+        label = torch.zeros(8, 5)
+        label[:, 0] = 1.0
+        _, mixed_label = mixup(mel, label, alpha=0.4)
+        assert mixed_label.min() >= 0.0
+        assert mixed_label.max() <= 1.0
+
+    def test_mel_is_convex_combination(self) -> None:
+        """混合後の mel が元の2サンプルの凸結合であること（alpha=1 → lambda=0.5 近辺）。"""
+        torch.manual_seed(42)
+        mel = torch.zeros(2, 1, 4, 4)
+        mel[0] = 1.0
+        mel[1] = 3.0
+        label = torch.zeros(2, 2)
+        mixed_mel, _ = mixup(mel, label, alpha=100.0)  # alpha 大きいと lambda ~ 0.5
+        # 混合値は 1.0 と 3.0 の間になるはず
+        assert mixed_mel.min() >= 1.0 - 1e-5
+        assert mixed_mel.max() <= 3.0 + 1e-5

--- a/tests/infrastructure/trainer/torch_utils/test_audio_augmentation.py
+++ b/tests/infrastructure/trainer/torch_utils/test_audio_augmentation.py
@@ -41,6 +41,22 @@ class TestSpecAugment:
         result = spec_augment(batch)
         assert result is batch
 
+    def test_per_sample_independent_masks(self) -> None:
+        """バッチ内の各サンプルに独立したマスクが適用されること。
+
+        バッチ全体で同一マスクの場合、全サンプルの (freq_zero_cols XOR time_zero_rows) が
+        完全一致する。per-sample ならばそれらが分岐するはずなので、
+        隣接サンプルのマスクを直接比較して少なくとも1組が異なることを確認する。
+        """
+        torch.manual_seed(42)
+        # 全サンプルを 1.0 で初期化
+        batch = torch.ones(8, 1, 64, 312)
+        result = spec_augment(batch.clone(), freq_mask_param=20, time_mask_param=60, n_masks=3)
+        # 各サンプルのゼロマスクをフラット化してタプルにする
+        masks = [tuple((result[i] == 0.0).flatten().tolist()) for i in range(8)]
+        # per-sample なら同一マスクが全部同じになることはほぼない（3マスク×8サンプルで多様性がある）
+        assert len(set(masks)) > 1
+
 
 class TestMixup:
     """mixup のテスト。"""

--- a/tests/presentation/test_runners.py
+++ b/tests/presentation/test_runners.py
@@ -1,0 +1,115 @@
+"""
+run_train のトレーナー型ディスパッチのテスト。
+
+なぜこのテストが必要か:
+- run_train が trainer.type=audio のとき AudioTrainer にディスパッチすることを検証する。
+- trainer.type が未登録のとき ValueError が発生することを確認する。
+- audio レシピ yaml が正しい trainer.type 構造を持つことを保証する。
+
+このテストがない場合、conf yaml に trainer_type: audio（フラットキー）と
+書いてもエラーが出ず、runner は ValueError を投げるだけになる。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from omegaconf import DictConfig, OmegaConf
+
+
+def _make_trainer_cfg(tmp_path: Path, trainer_type: str) -> DictConfig:
+    """run_train に渡す最小限の trainer DictConfig を生成する。"""
+    return OmegaConf.create(
+        {
+            "trainer": {"type": trainer_type},
+            "preprocess_output_dir": str(tmp_path / "preprocess"),
+            "output_dir": str(tmp_path / "models"),
+            "job_id": f"test_{trainer_type}",
+            "competition": {"name": "audio_example"},
+            "seed": 42,
+            "metric": "roc_auc",
+            "spectrogram": {
+                "sample_rate": 32000,
+                "n_fft": 2048,
+                "hop_length": 512,
+                "n_mels": 128,
+                "segment_seconds": 5.0,
+            },
+            "model": {
+                "backbone": "efficientnet_b0",
+                "pretrained": False,
+                "num_classes": 3,
+            },
+            "training": {"epochs": 1, "batch_size": 4, "lr": 1e-3, "weight_decay": 1e-4},
+        }
+    )
+
+
+class TestRunTrainAudioDispatch:
+    """run_train の audio ディスパッチテスト。"""
+
+    def test_audio_trainer_is_dispatched(self, tmp_path: Path) -> None:
+        """trainer.type=audio のとき AudioTrainer が使われ ValueError が発生しないこと。"""
+        from src.presentation.runners import run_train
+
+        cfg = OmegaConf.create({"competition": {"name": "audio_example"}, "usecase": "train"})
+        trainer_cfg = _make_trainer_cfg(tmp_path, "audio")
+
+        mock_result = MagicMock()
+        mock_result.job_id = "test_audio"
+        mock_result.metric = "roc_auc"
+        mock_result.cv_mean_score = 0.7
+        mock_result.cv_std_score = 0.05
+
+        with (
+            patch(
+                "src.usecase.training.trainer_loader.load_trainer_cfgs",
+                return_value=[trainer_cfg],
+            ),
+            patch("src.infrastructure.repository.git.GitRepositoryImpl"),
+            patch("src.usecase.training.train.TrainUseCase") as mock_uc,
+        ):
+            mock_uc.return_value.execute.return_value = mock_result
+            run_train(cfg)
+
+        mock_uc.assert_called_once()
+        _, kwargs = mock_uc.call_args
+        from src.infrastructure.trainer.audio_trainer import AudioTrainer
+
+        assert isinstance(kwargs["trainer"], AudioTrainer)
+
+    def test_unknown_trainer_type_raises(self, tmp_path: Path) -> None:
+        """trainer.type が未登録の場合は ValueError が発生すること。"""
+        from src.presentation.runners import run_train
+
+        cfg = OmegaConf.create({"competition": {"name": "audio_example"}, "usecase": "train"})
+        trainer_cfg = _make_trainer_cfg(tmp_path, "unknown_type")
+
+        with (
+            patch(
+                "src.usecase.training.trainer_loader.load_trainer_cfgs",
+                return_value=[trainer_cfg],
+            ),
+            patch("src.infrastructure.repository.git.GitRepositoryImpl"),
+        ):
+            with pytest.raises(ValueError, match="trainer.type='unknown_type'"):
+                run_train(cfg)
+
+    def test_audio_recipe_yaml_uses_nested_trainer_type(self) -> None:
+        """efficientnet_b0.yaml が trainer.type: audio（ネスト形式）を使っていること。
+
+        trainer_type: audio（フラットキー）では run_train がキーを読めずに
+        AttributeError / KeyError を起こす。このテストがあれば yaml の構造ミスを早期検知できる。
+        """
+        conf_dir = Path(__file__).parent.parent.parent / "conf"
+        yaml_path = conf_dir / "competition" / "audio_example" / "training" / "efficientnet_b0.yaml"
+        assert yaml_path.exists(), f"yaml が見つかりません: {yaml_path}"
+        cfg = OmegaConf.load(yaml_path)
+        assert hasattr(cfg, "trainer"), (
+            "trainer キーが存在しません（trainer_type ではなく trainer.type を使うこと）"
+        )
+        assert cfg.trainer.type == "audio", (
+            f"trainer.type が audio ではありません: {cfg.trainer.type!r}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-18T09:43:20.929426071Z"
+exclude-newer = "2026-06-19T01:41:28.557842024Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -261,6 +261,76 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -1520,6 +1590,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "scikit-learn" },
     { name = "seaborn" },
+    { name = "soundfile" },
     { name = "torch" },
     { name = "torchvision" },
 ]
@@ -1555,6 +1626,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "scikit-learn", specifier = ">=1.3" },
     { name = "seaborn", specifier = ">=0.12" },
+    { name = "soundfile", specifier = ">=0.12" },
     { name = "torch", specifier = ">=2.0" },
     { name = "torchvision", specifier = ">=0.15" },
 ]
@@ -2416,6 +2488,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2975,6 +3056,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soundfile"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/d1/5e338af9ca6ed0786cd5bb03f6d60de1c325728c1189014f3b59aae7403c/soundfile-0.14.0-py2.py3-none-any.whl", hash = "sha256:8ba81ae3a89fd5ab3bef8a8eb481fbbe794e806309675a89b4df48b8d31908a8", size = 26799, upload-time = "2026-06-06T08:58:33.269Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/72/c6b21e58d3113596e7e8de0a08d6f1d95173492cfbca0a4db14148cbba2a/soundfile-0.14.0-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:19be05428da76ed61a4cad29b8e4bcf43a3e5c100089d2ec81dc961eed1b0dd4", size = 1144568, upload-time = "2026-06-06T08:58:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/dfdd6f8c748988427119f75eb860a3cedd858d1aea1fe28f39ad8559ef22/soundfile-0.14.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d828d35a059626da52f1415b5faee610aeab393319cb3fc4a9aef47b619fc14c", size = 1103726, upload-time = "2026-06-06T08:58:37.948Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f8/fc39fad6f879633461d27394cd1ddaf1f769ffa0597dca35872f51b16461/soundfile-0.14.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e85724a90bc99a6e8062c0b4ddf725f53b2a3b70afd4da875e9d2cfc4e92f377", size = 1238050, upload-time = "2026-06-06T08:58:39.932Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a2/70fd4432b924684c372df8b0a45708c36c057ef3596c9eb53e0a806b980b/soundfile-0.14.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:1e38bac1853412871318e82a1ba69a8be677619b56025bbfcccdb41b6cafe82d", size = 1315963, upload-time = "2026-06-06T08:58:41.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/34/c9e80783d83eab739a9531fdee03675d53e0bf1b2ccb4bb3af5844675046/soundfile-0.14.0-py2.py3-none-win32.whl", hash = "sha256:0a6ae43c50c71b4e020cc55382925cb89451c1ed1a0c3d0f5d802da269226849", size = 902199, upload-time = "2026-06-06T08:58:43.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/97/b39c18ac1df45e755ca22b8b00e872929da5d107998a207a5e4ac831bfda/soundfile-0.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:299491d3499460fb1b74bb4bd78b57ffc2d243a5fafa7b6ec1b264875c78453e", size = 1021480, upload-time = "2026-06-06T08:58:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/83/55c65e61cf457805ce2ec157c1c6ae17715d0851aa2374422de0538838ca/soundfile-0.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:e090704718e124e7c844695236f1fce8d18a5e761eaf7c82dfcd124620805f98", size = 888858, upload-time = "2026-06-06T08:58:46.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `src/domain/data/audio.py`: `AudioSample` / `AudioLoader` Protocol / `SpectrogramConfig` / `SpectrogramTransformer` Protocol を定義（domain 層、外部ライブラリ依存なし）
- `src/infrastructure/audio/soundfile_loader.py`: `SoundfileLoader`（AudioLoader 実装）
- `src/infrastructure/audio/mel_spectrogram.py`: `MelSpectrogramTransformer`（torchaudio 非依存、numpy + torch.stft でメルスペクトログラム生成）
- `src/infrastructure/trainer/torch_utils/audio_augmentation.py`: `spec_augment()` / `mixup()` を public 化（per-sample 独立マスク）
- `src/infrastructure/trainer/audio_trainer.py`: `AudioTrainer`（Trainer Protocol 実装、SeedFixer DI、cfg 経由で backbone / num_classes / augmentation を制御）
- `pyproject.toml` / `mille.toml`: `soundfile>=0.12` を追加
- `conf/competition/audio_example/`: サンプル設定（EfficientNet-B0 + SpecAugment + Mixup）
- `docs/manual/audio-foundation.md`: 新コンペ追加手順・manifest 形式・設定パラメータを記載

## 設計方針

- **bird-clef-2026 から BirdCLEF 固有部分を除いた汎用化**: Perch embedding / TensorFlow / 234-class taxonomy は Phase 2 以降
- **VisionTrainer と同じ DI パターン**: `SeedFixer` をコンストラクタで受け取り、デフォルトは `TorchSeedFixer`
- **全陽性クラスの ROC-AUC クラッシュ防止**: `col_sums < n_samples` ガードを追加（DAレビューで発見）
- **spec_augment をサンプルごとの独立マスクに修正**（DAレビューで発見）

## Test plan

- [ ] `uv run pytest` — 561 tests passed
- [ ] `uv run ruff check .` — All checks passed
- [ ] `uv run ruff format --check .` — 232 files already formatted
- [ ] `uv run ty check src/ tests/ --python .venv` — All checks passed
- [ ] `uv run mille check` — 0 violations across all layers
- [ ] DAレビュー完了・指摘4件（高1・中3）すべて対応済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)